### PR TITLE
Fix config.json emoji_id's

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,6 +33,8 @@
 "//": "Emoji for raid organization",
 "omw_id": ":omw:",
 "here_id": ":here:",
+"unomw_id": ":unomw:",
+"unhere_id": ":unhere:",
 
 "//": "Emoji for Pokemon types.",
 "type_id_dict": {


### PR DESCRIPTION
fix unassigned emoji_id that causes exception errors when generating raids.