### PR TITLE
Template tag parser, template sample cmd, configure welcome change, ask helper

### DIFF
--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -345,13 +345,23 @@ async def template(ctx, *, sample_message):
     embed = None
     msg, errors = do_template(sample_message, ctx.message.author, ctx.message.server)
     if errors:
-        msg = ("{}\n\n**Warning:**\nThe following could not be found: {}"
-               "").format(msg, ', '.join(errors))
-    if msg.startswith("[") and msg.endswith("]"):
-        await Meowth.send_message(ctx.message.channel, embed=discord.Embed(
-            colour=ctx.message.server.me.colour, description=msg[1:-1]))
+        if msg.startswith("[") and msg.endswith("]"):
+            embed = discord.Embed(
+                colour=ctx.message.server.me.colour, description=msg[1:-1])
+            embed.add_field(
+                name='Warning',
+                value='The following could not be found:\n{}'.format('\n'.join(errors)))
+            await Meowth.send_message(ctx.message.channel, embed=embed)
+        else:
+            msg = ("{}\n\n**Warning:**\nThe following could not be found: {}"
+                   "").format(msg, ', '.join(errors))
+            await Meowth.send_message(ctx.message.channel, msg)
     else:
-        await Meowth.send_message(ctx.message.channel, msg)
+        if msg.startswith("[") and msg.endswith("]"):
+            await Meowth.send_message(ctx.message.channel, embed=discord.Embed(
+                colour=ctx.message.server.me.colour, description=msg[1:-1]))
+        else:
+            await Meowth.send_message(ctx.message.channel, msg)
 
 
 """

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -329,7 +329,6 @@ async def ask(message, destination, user_id, *, react_list=['✅', '❎']):
         await asyncio.sleep(0.25)
         await Meowth.add_reaction(msg, r)
     res = await Meowth.wait_for_reaction(react_list, message=msg, check=check, timeout=60)
-    await Meowth.delete_message(msg)
     return res.reaction.emoji if res else None
 
 @Meowth.command(pass_context=True, hidden=True)
@@ -338,10 +337,10 @@ async def template(ctx, *, sample_message):
     embed = None
     msg = do_template(sample_message, ctx.message.author, ctx.message.server)
     if msg.startswith("[") and msg.endswith("]"):
-        embed = discord.Embed(colour=ctx.message.server.me.colour, description=msg[1:-1])
-    res = await ask(embed or msg, ctx.message.channel, ctx.message.author.id, react_list=['\N{WASTEBASKET}'])
-    if res == '\N{WASTEBASKET}':
-        await Meowth.delete_message(msg)
+        await Meowth.send_message(ctx.message.channel, embed=discord.Embed(
+            colour=ctx.message.server.me.colour, description=msg[1:-1]))
+    else:
+        await Meowth.send_message(ctx.message.channel, msg)
 
 
 """


### PR DESCRIPTION
I've added a parsing function for the message template setup used for custom welcome messages.
The parser uses regex to match and replace the template tags that match and exist as valid objects.

In order to assist people sampling custom welcome messages in their own guild first, as well as to let groups of people easily collaborate together to discuss, sample and decide on a custom welcome message, I've added a command called `template` that accepts a sample message using the template tags and gives a parsed output of the sample.

Additionally, since there was a need to setup twice a wait_for_reaction, I just make a helper function called ask that accepts the following args: message (str or embed), destination (channel or user), user_id, and an optional keyword arg called react_list that lets you override the default tick/cross reaction options.
This should help minimise repetitive wait_for_reaction code a little bit, but since it's outside of the scope of this feature branch, I have not actually applied this new function to any other reaction confirmation messages outside of the ones created in these edits.