### PR TITLE
Latitude/Longitude support in gmaps lookup

### DIFF
--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -262,7 +262,7 @@ def create_gmaps_query(details, channel):
 
 	#look for lat/long coordinates in the location details. If provided, 
 	#then channel location hints are not needed in the  maps query
-	if re.match (r'-?\d{1,2}\.?\d*,\s+-?\d{1,3}\.?\d*', details): #regex looks for lat/long in the format similar to 42.434546, -83.985195. 
+	if re.match (r'^\s*-?\d{1,2}\.?\d*,\s+-?\d{1,3}\.?\d*\s*$', details): #regex looks for lat/long in the format similar to 42.434546, -83.985195. 
 		return "https://www.google.com/maps/search/?api=1&query={0}".format('+'.join(details_list))
 			
 			

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -260,6 +260,12 @@ def create_gmaps_query(details, channel):
             newloc = details[newlocindex:newlocend+1]
             return newloc
 
+	#look for lat/long coordinates in the location details. If provided, 
+	#then channel location hints are not needed in the  maps query
+	if re.match (r'-?\d{1,2}\.?\d*,\s+-?\d{1,3}\.?\d*', details): #regex looks for lat/long in the format similar to 42.434546, -83.985195. 
+		return "https://www.google.com/maps/search/?api=1&query={0}".format('+'.join(details_list))
+			
+			
     details_list = details.split()
     loc_list = server_dict[channel.server.id]['city_channels'][channel.name].split()
     return "https://www.google.com/maps/search/?api=1&query={0}+{1}".format('+'.join(details_list),'+'.join(loc_list))


### PR DESCRIPTION
With the current gmaps query function, the discord channel information is appended to any latitude/longitude coordinates that are given. The gmaps lookup can't handle the coordinates properly with trailing text, so I've added a check so that if the location details are only two comma separated numbers, then the channel location hints are not appended.

 Should also fix issue #139