### PR TITLE
Fixes to translation and to bugs reported in discord channel

### DIFF
--- a/locale/meowth.pot
+++ b/locale/meowth.pot
@@ -1608,7 +1608,7 @@ msgstr ""
 
 #: __main__.py:3569
 msgid ""
-"{pkmn} | {weather}\n"
+"{pkmn} | {weather}"
 msgstr ""
 
 #: __main__.py:3570

--- a/locale/meowth.pot
+++ b/locale/meowth.pot
@@ -1,16 +1,16 @@
-# Meowth Discord Bot Translation Template.
-# Scragly, 2017.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: 2018-03-07 14:55+0100\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2018-03-11 02:35+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=cp1252\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: pygettext.py 1.5\n"
 
@@ -99,6 +99,7 @@ msgid "Meowth! I'm Meowth, a Discord helper bot for Pokemon Go communities, and 
 msgstr ""
 
 #: __main__.py:819
+#: __main__.py:1930
 msgid " or "
 msgstr ""
 
@@ -116,12 +117,12 @@ msgstr ""
 
 #: __main__.py:863
 #: __main__.py:875
-#: __main__.py:4064
+#: __main__.py:4086
 msgid "Meowth! Please wait until the raid egg has hatched before announcing you're coming or present."
 msgstr ""
 
 #: __main__.py:909
-#: __main__.py:3232
+#: __main__.py:3235
 msgid "Meowth! Someone has suggested a different location for the raid! Trainers {trainer_list}: make sure you are headed to the right place!"
 msgstr ""
 
@@ -729,321 +730,377 @@ msgstr ""
 msgid "The channel you entered is not a raid channel."
 msgstr ""
 
-#: __main__.py:1773
-#: __main__.py:1776
-#: __main__.py:2520
-#: __main__.py:2523
-#: __main__.py:2844
-#: __main__.py:2847
-msgid "**Possible Bosses:**"
+#: __main__.py:1757
+#: __main__.py:2514
+msgid "level-{egg_level}-egg-"
 msgstr ""
 
-#: __main__.py:1773
-#: __main__.py:2520
-#: __main__.py:2844
-#: __main__.py:4031
-msgid "{bosslist1}"
+#: __main__.py:1774
+#: __main__.py:1777
+#: __main__.py:2521
+#: __main__.py:2524
+#: __main__.py:2846
+#: __main__.py:2849
+#: __main__.py:4053
+#: __main__.py:4056
+msgid "**Possible Bosses:**"
 msgstr ""
 
 #: __main__.py:1774
 #: __main__.py:2521
-#: __main__.py:2845
-#: __main__.py:4032
+#: __main__.py:2846
+#: __main__.py:4053
+msgid "{bosslist1}"
+msgstr ""
+
+#: __main__.py:1775
+#: __main__.py:2522
+#: __main__.py:2847
+#: __main__.py:4054
 msgid "{bosslist2}"
 msgstr ""
 
-#: __main__.py:1776
-#: __main__.py:2523
-#: __main__.py:2847
-#: __main__.py:4034
+#: __main__.py:1777
+#: __main__.py:2524
+#: __main__.py:2849
+#: __main__.py:4056
 msgid "{bosslist}"
-msgstr ""
-
-#: __main__.py:1781
-#: __main__.py:2611
-#: __main__.py:2752
-#: __main__.py:3220
-#: __main__.py:3234
-#: __main__.py:4025
-msgid "team"
 msgstr ""
 
 #: __main__.py:1782
 #: __main__.py:2612
-#: __main__.py:2753
-#: __main__.py:3221
-#: __main__.py:3235
-#: __main__.py:4026
+#: __main__.py:2754
+#: __main__.py:3223
+#: __main__.py:3237
+#: __main__.py:4047
+msgid "team"
+msgstr ""
+
+#: __main__.py:1783
+#: __main__.py:2613
+#: __main__.py:2755
+#: __main__.py:3224
+#: __main__.py:3238
+#: __main__.py:4048
 msgid "status"
 msgstr ""
 
-#: __main__.py:1804
+#: __main__.py:1786
+#: __main__.py:1787
+msgid "Level {}"
+msgstr ""
+
+#: __main__.py:1786
+#: __main__.py:1787
+msgid "level\\s\\d"
+msgstr ""
+
+#: __main__.py:1805
 msgid "Are you sure you want to clear all status for this raid? Everybody will have to RSVP again. If you are wanting to clear one user's status, use `!setstatus <user> cancel`"
 msgstr ""
 
-#: __main__.py:1831
+#: __main__.py:1817
+msgid "Meowth! Raid status lists have been cleared!"
+msgstr ""
+
+#: __main__.py:1832
 msgid "Meowth! {status} is not a valid status!"
 msgstr ""
 
-#: __main__.py:1846
+#: __main__.py:1847
 msgid "Removed {cleancount} empty roles"
 msgstr ""
 
-#: __main__.py:1860
+#: __main__.py:1861
 msgid "Uptime"
 msgstr ""
 
-#: __main__.py:1943
+#: __main__.py:1865
+#: __main__.py:1917
+msgid "I need the `Embed links` permission to send this"
+msgstr ""
+
+#: __main__.py:1874
+msgid "{yr}y {mth}m {day}d {hr}:{min}"
+msgstr ""
+
+#: __main__.py:1876
+msgid "{mth}m {day}d {hr}:{min}"
+msgstr ""
+
+#: __main__.py:1878
+msgid "{day} days {hr} hrs {min} mins"
+msgstr ""
+
+#: __main__.py:1880
+msgid "{hr} hrs {min} mins {sec} secs"
+msgstr ""
+
+#: __main__.py:1882
+msgid "{min} mins {sec} secs"
+msgstr ""
+
+#: __main__.py:1898
+msgid ""
+"I'm Meowth! A Pokemon Go helper bot for Discord!\n"
+"\n"
+"I'm made by [{author_name}]({author_repo}) and improvements have been contributed by many other people also.\n"
+"\n"
+"[Join our server]({server_invite}) if you have any questions or feedback.\n"
+"\n"
+msgstr ""
+
+#: __main__.py:1944
 msgid "Maximum guild roles reached."
 msgstr ""
 
-#: __main__.py:1948
+#: __main__.py:1949
 msgid ""
 "Meowth! My roles are ranked lower than the following team roles: **{higher_roles_list}**\n"
 "Please get an admin to move my roles above them!"
 msgstr ""
 
-#: __main__.py:1970
+#: __main__.py:1971
 msgid "Meowth! You already have a team role!"
 msgstr ""
 
-#: __main__.py:1974
+#: __main__.py:1975
 msgid "Meowth! You are already in Team Harmony!"
 msgstr ""
 
-#: __main__.py:1978
+#: __main__.py:1979
 msgid "Meowth! {team_role} is not configured as a role on this server. Please contact an admin for assistance."
 msgstr ""
 
-#: __main__.py:1982
+#: __main__.py:1983
 msgid "Meowth! \"{entered_team}\" isn't a valid team! Try {available_teams}"
 msgstr ""
 
-#: __main__.py:1986
+#: __main__.py:1987
 msgid "Meowth! The \"{entered_team}\" role isn't configured on this server! Contact an admin!"
 msgstr ""
 
-#: __main__.py:1992
+#: __main__.py:1993
 msgid "Meowth! Added {member} to Team {team_name}! {team_emoji}"
 msgstr ""
 
-#: __main__.py:1994
+#: __main__.py:1995
 msgid "Meowth! I can't add roles!"
 msgstr ""
 
-#: __main__.py:2001
+#: __main__.py:2002
 msgid "Meowth! We've moved this command to **!list interested**."
 msgstr ""
 
-#: __main__.py:2006
+#: __main__.py:2007
 msgid "Meowth! We've moved this command to **!list coming**."
 msgstr ""
 
-#: __main__.py:2011
+#: __main__.py:2012
 msgid "Meowth! We've moved this command to **!list here**."
 msgstr ""
 
-#: __main__.py:2016
+#: __main__.py:2017
 msgid "Meowth! Hey {member}, I don't know if you meant **!coming** to say that you are coming or **!list coming** to see the other trainers on their way"
 msgstr ""
 
-#: __main__.py:2074
-#: __main__.py:2161
-#: __main__.py:2367
-#: __main__.py:2572
-#: __main__.py:2638
+#: __main__.py:2075
+#: __main__.py:2162
+#: __main__.py:2368
+#: __main__.py:2573
+#: __main__.py:2639
 msgid "Meowth! **{word}** isn't a Pokemon!"
 msgstr ""
 
-#: __main__.py:2087
+#: __main__.py:2088
 msgid "Maximum guild roles reached. Pokemon not added."
 msgstr ""
 
-#: __main__.py:2107
+#: __main__.py:2108
 msgid "Meowth! Got it! {member} wants {pokemon}"
 msgstr ""
 
-#: __main__.py:2110
+#: __main__.py:2111
 msgid "Meowth! {member}, I already know you want {pokemon}!"
 msgstr ""
 
-#: __main__.py:2113
+#: __main__.py:2114
 msgid "Meowth! {member}, out of your total {count} items:"
 msgstr ""
 
-#: __main__.py:2115
+#: __main__.py:2116
 msgid ""
 "\n"
 "**{added_count} Added:** \n"
 "\t{added_list}"
 msgstr ""
 
-#: __main__.py:2117
+#: __main__.py:2118
 msgid ""
 "\n"
 "**{already_want_count} Already Following:** \n"
 "\t{already_want_list}"
 msgstr ""
 
-#: __main__.py:2121
+#: __main__.py:2122
 msgid ""
 "\n"
 "\t{word}"
 msgstr ""
 
-#: __main__.py:2123
+#: __main__.py:2124
 msgid ": *({correction}?)*"
 msgstr ""
 
-#: __main__.py:2124
+#: __main__.py:2125
 msgid ""
 "\n"
 "**{count} Not Valid:**"
 msgstr ""
 
-#: __main__.py:2163
-#: __main__.py:2369
-#: __main__.py:2574
-#: __main__.py:2640
+#: __main__.py:2164
+#: __main__.py:2370
+#: __main__.py:2575
+#: __main__.py:2641
 msgid " Did you mean **{correction}**?"
 msgstr ""
 
-#: __main__.py:2213
+#: __main__.py:2214
 msgid "{0}, you have no pokemon in your want list."
 msgstr ""
 
-#: __main__.py:2215
+#: __main__.py:2216
 msgid "{0}, I've removed {1} pokemon from your want list."
 msgstr ""
 
-#: __main__.py:2234
-#: __main__.py:2303
-#: __main__.py:2460
-#: __main__.py:2802
-#: __main__.py:2957
-#: __main__.py:2964
+#: __main__.py:2235
+#: __main__.py:2304
+#: __main__.py:2461
+#: __main__.py:2804
+#: __main__.py:2959
 #: __main__.py:2966
-#: __main__.py:3134
-#: __main__.py:3147
-#: __main__.py:3151
-#: __main__.py:3160
-#: __main__.py:4165
-#: __main__.py:4325
-#: __main__.py:4330
-#: __main__.py:4334
-#: __main__.py:4381
-#: __main__.py:4646
+#: __main__.py:2968
+#: __main__.py:3136
+#: __main__.py:3149
+#: __main__.py:3153
+#: __main__.py:3162
+#: __main__.py:4187
+#: __main__.py:4347
+#: __main__.py:4352
+#: __main__.py:4356
+#: __main__.py:4403
+#: __main__.py:4668
 msgid "%I:%M %p (%H:%M)"
 msgstr ""
 
-#: __main__.py:2238
-#: __main__.py:2252
+#: __main__.py:2239
+#: __main__.py:2253
 msgid "Meowth! Give more details when reporting! Usage: **!wild <pokemon name> <location>**"
 msgstr ""
 
-#: __main__.py:2260
+#: __main__.py:2261
 msgid "Meowth! {word} isn't a Pokemon!"
 msgstr ""
 
-#: __main__.py:2262
+#: __main__.py:2263
 msgid " Did you mean {correction}?"
 msgstr ""
 
-#: __main__.py:2272
+#: __main__.py:2273
 msgid "Ask {author} if my directions aren't perfect!"
 msgstr ""
 
-#: __main__.py:2272
+#: __main__.py:2273
 msgid "Meowth! Click here for my directions to the wild {pokemon}!"
 msgstr ""
 
-#: __main__.py:2273
-#: __main__.py:2410
-#: __main__.py:2608
-#: __main__.py:2723
+#: __main__.py:2274
+#: __main__.py:2411
+#: __main__.py:2609
+#: __main__.py:2725
 msgid "**Details:**"
 msgstr ""
 
-#: __main__.py:2273
-#: __main__.py:2410
-#: __main__.py:2608
-#: __main__.py:2723
+#: __main__.py:2274
+#: __main__.py:2411
+#: __main__.py:2609
+#: __main__.py:2725
 msgid "{pokemon} ({pokemonnumber}) {type}"
 msgstr ""
 
-#: __main__.py:2275
-#: __main__.py:2277
-#: __main__.py:2413
-#: __main__.py:2415
-#: __main__.py:2526
-#: __main__.py:2528
-#: __main__.py:2850
+#: __main__.py:2276
+#: __main__.py:2278
+#: __main__.py:2414
+#: __main__.py:2416
+#: __main__.py:2527
+#: __main__.py:2529
 #: __main__.py:2852
+#: __main__.py:2854
 msgid "Reported by @{author} - {timestamp}"
 msgstr ""
 
-#: __main__.py:2279
+#: __main__.py:2280
 msgid "Meowth! Wild {pokemon} reported by {member}! Details: {location_details}"
 msgstr ""
 
-#: __main__.py:2280
+#: __main__.py:2281
 msgid "**This {pokemon} has despawned!**"
 msgstr ""
 
-#: __main__.py:2310
+#: __main__.py:2311
 msgid "Meowth! Please restrict raid reports to a city channel!"
 msgstr ""
 
-#: __main__.py:2315
-#: __main__.py:2343
-#: __main__.py:2396
+#: __main__.py:2316
+#: __main__.py:2344
+#: __main__.py:2397
 msgid "Meowth! Give more details when reporting! Usage: **!raid <pokemon name> <location>**"
 msgstr ""
 
-#: __main__.py:2325
+#: __main__.py:2326
 msgid "Meowth! **!raid assume** is not allowed in this level egg."
 msgstr ""
 
-#: __main__.py:2337
+#: __main__.py:2338
 msgid "Meowth! Please wait until the egg has hatched before changing it to an open raid!"
 msgstr ""
 
-#: __main__.py:2384
-#: __main__.py:2592
-#: __main__.py:2707
+#: __main__.py:2385
+#: __main__.py:2593
+#: __main__.py:2709
 msgid "Meowth! The Pokemon {pokemon} does not appear in raids!"
 msgstr ""
 
-#: __main__.py:2387
+#: __main__.py:2388
 msgid "Meowth! The Pokemon {pokemon} only appears in EX Raids! Use **!exraid** to report one!"
 msgstr ""
 
-#: __main__.py:2391
+#: __main__.py:2392
 msgid "Meowth...that's too long. Level {raidlevel} raids currently last no more than {raidtime} minutes..."
 msgstr ""
 
-#: __main__.py:2409
-#: __main__.py:2722
+#: __main__.py:2410
+#: __main__.py:2724
 msgid "Meowth! Click here for directions to the raid!"
 msgstr ""
 
-#: __main__.py:2411
-#: __main__.py:2609
-#: __main__.py:2724
+#: __main__.py:2412
+#: __main__.py:2610
+#: __main__.py:2726
 msgid "**Weaknesses:**"
 msgstr ""
 
-#: __main__.py:2411
-#: __main__.py:2609
-#: __main__.py:2724
+#: __main__.py:2412
+#: __main__.py:2610
+#: __main__.py:2726
 msgid "{weakness_list}"
 msgstr ""
 
-#: __main__.py:2417
+#: __main__.py:2418
 msgid "Meowth! {pokemon} raid reported by {member}! Details: {location_details}. Coordinate in {raid_channel}"
 msgstr ""
 
-#: __main__.py:2419
+#: __main__.py:2420
 msgid ""
 "Meowth! {pokemon} raid reported by {member} in {citychannel}! Details: {location_details}. Coordinate here!\n"
 "\n"
@@ -1063,42 +1120,38 @@ msgid ""
 "This channel will be deleted five minutes after the timer expires."
 msgstr ""
 
-#: __main__.py:2440
+#: __main__.py:2441
 msgid "Meowth! Hey {member}, if you can, set the time left on the raid using **!timerset <minutes>** so others can check it with **!timer**."
 msgstr ""
 
-#: __main__.py:2466
+#: __main__.py:2467
 msgid "Meowth! Give more details when reporting! Usage: **!raidegg <level> <location>**"
 msgstr ""
 
-#: __main__.py:2472
-#: __main__.py:2498
+#: __main__.py:2473
+#: __main__.py:2499
 msgid "Meowth! Give more details when reporting! Use at least: **!raidegg <level> <location>**. Type **!help** raidegg for more info."
 msgstr ""
 
-#: __main__.py:2493
+#: __main__.py:2494
 msgid "Meowth...that's too long. Level {raidlevel} Raid Eggs currently last no more than {hatchtime} minutes..."
 msgstr ""
 
-#: __main__.py:2502
+#: __main__.py:2503
 msgid "Meowth! Raid egg levels are only from 1-5!"
 msgstr ""
 
-#: __main__.py:2513
-msgid "level-{egg_level}-egg-"
-msgstr ""
-
-#: __main__.py:2518
-#: __main__.py:2607
-#: __main__.py:2842
+#: __main__.py:2519
+#: __main__.py:2608
+#: __main__.py:2844
 msgid "Meowth! Click here for directions to the coming raid!"
 msgstr ""
 
-#: __main__.py:2530
+#: __main__.py:2531
 msgid "Meowth! Level {level} raid egg reported by {member}! Details: {location_details}. Coordinate in {raid_channel}"
 msgstr ""
 
-#: __main__.py:2532
+#: __main__.py:2533
 msgid ""
 "Meowth! Level {level} raid egg reported by {member} in {citychannel}! Details: {location_details}. Coordinate here!\n"
 "\n"
@@ -1118,24 +1171,31 @@ msgid ""
 "This channel will be deleted five minutes after the timer expires."
 msgstr ""
 
-#: __main__.py:2553
+#: __main__.py:2554
 msgid "Meowth! Hey {member}, if you can, set the time left until the egg hatches using **!timerset <minutes>** so others can check it with **!timer**."
 msgstr ""
 
-#: __main__.py:2595
-#: __main__.py:2710
+#: __main__.py:2596
+#: __main__.py:2712
 msgid "Meowth! The Pokemon {pokemon} does not hatch from level {level} raid eggs!"
 msgstr ""
 
-#: __main__.py:2627
+#: __main__.py:2628
 msgid "Meowth! This egg will be assumed to be {pokemon} when it hatches!"
 msgstr ""
 
-#: __main__.py:2699
+#: __main__.py:2673
+#: __main__.py:3211
+#: __main__.py:3275
+#: __main__.py:4039
+msgid "Coordinate here"
+msgstr ""
+
+#: __main__.py:2701
 msgid "Meowth! The egg has hatched into a {pokemon} raid! Details: {location_details}. Coordinate in {raid_channel}"
 msgstr ""
 
-#: __main__.py:2700
+#: __main__.py:2702
 msgid ""
 "Meowth! The egg reported by {member} in {citychannel} hatched into a {pokemon} raid! Details: {location_details}. Coordinate here!\n"
 "\n"
@@ -1155,11 +1215,11 @@ msgid ""
 "This channel will be deleted five minutes after the timer expires."
 msgstr ""
 
-#: __main__.py:2703
+#: __main__.py:2705
 msgid "Meowth! The EX egg has hatched into a {pokemon} raid! Details: {location_details}. Use the **!invite** command to gain access and coordinate in {raid_channel}"
 msgstr ""
 
-#: __main__.py:2704
+#: __main__.py:2706
 msgid ""
 "Meowth! {pokemon} EX raid reported by {member} in {citychannel}! Details: {location_details}. Coordinate here after using **!invite** to gain access!\n"
 "\n"
@@ -1179,30 +1239,30 @@ msgid ""
 "This channel will be deleted five minutes after the timer expires."
 msgstr ""
 
-#: __main__.py:2727
+#: __main__.py:2729
 msgid "Ends on %B %d at %I:%M %p (%H:%M)"
 msgstr ""
 
-#: __main__.py:2750
+#: __main__.py:2752
 msgid ""
 "Meowth! Trainers {trainer_list}: The raid egg has just hatched into a {pokemon} raid!\n"
 "If you couldn't before, you're now able to update your status with **!coming** or **!here**. If you've changed your plans, use **!cancel**."
 msgstr ""
 
-#: __main__.py:2807
-#: __main__.py:2814
+#: __main__.py:2809
+#: __main__.py:2816
 msgid "Meowth! Give more details when reporting! Usage: **!exraid <location>**"
 msgstr ""
 
-#: __main__.py:2826
+#: __main__.py:2828
 msgid "ex-raid-egg-"
 msgstr ""
 
-#: __main__.py:2854
+#: __main__.py:2856
 msgid "Meowth! EX raid egg reported by {member}! Details: {location_details}. Use the **!invite** command to gain access and coordinate in {raid_channel}"
 msgstr ""
 
-#: __main__.py:2856
+#: __main__.py:2858
 msgid ""
 "Meowth! EX raid reported by {member} in {citychannel}! Details: {location_details}. Coordinate here after using **!invite** to gain access!\n"
 "\n"
@@ -1222,605 +1282,708 @@ msgid ""
 "This channel will be deleted five minutes after the timer expires."
 msgstr ""
 
-#: __main__.py:2876
+#: __main__.py:2878
 msgid "Meowth! Hey {member}, if you can, set the time left until the egg hatches using **!timerset <date and time>** so others can check it with **!timer**. **<date and time>** can just be written exactly how it appears on your EX Raid Pass."
 msgstr ""
 
-#: __main__.py:2923
+#: __main__.py:2925
 msgid "Meowth! No EX Raids have been reported in this server! Use **!exraid** to report one!"
 msgstr ""
 
-#: __main__.py:2925
+#: __main__.py:2927
 msgid ""
 "Meowth! {0}, you've told me you have an invite to an EX Raid, and I'm just going to take your word for it! The following {1} EX Raids have been reported:\n"
 "{2}\n"
 "Reply with **the number** (1, 2, etc) of the EX Raid you have been invited to. If none of them match your invite, type 'N' and report it with **!exraid**"
 msgstr ""
 
-#: __main__.py:2928
+#: __main__.py:2930
 msgid "Meowth! Be sure to report your EX Raid with **!exraid**!"
 msgstr ""
 
-#: __main__.py:2930
+#: __main__.py:2932
 msgid "Meowth! I couldn't tell which EX Raid you meant! Try the **!invite** command again, and make sure you respond with the number of the channel that matches!"
 msgstr ""
 
-#: __main__.py:2937
+#: __main__.py:2939
 msgid "Meowth! Alright {0}, you can now send messages in {1}! Make sure you let the trainers in there know if you can make it to the EX Raid!"
 msgstr ""
 
-#: __main__.py:2940
+#: __main__.py:2942
 msgid "Meowth! I couldn't understand your reply! Try the **!invite** command again!"
 msgstr ""
 
-#: __main__.py:2951
-#: __main__.py:3277
-#: __main__.py:3314
-#: __main__.py:3390
+#: __main__.py:2953
+#: __main__.py:3412
 msgid "egg"
 msgstr ""
 
-#: __main__.py:2952
-#: __main__.py:3391
+#: __main__.py:2954
+#: __main__.py:3411
 msgid "hatch"
 msgstr ""
 
-#: __main__.py:2954
-#: __main__.py:3298
-#: __main__.py:3392
+#: __main__.py:2956
+#: __main__.py:3415
 msgid "raid"
 msgstr ""
 
-#: __main__.py:2955
-#: __main__.py:3393
+#: __main__.py:2957
+#: __main__.py:3414
 msgid "end"
 msgstr ""
 
-#: __main__.py:2957
+#: __main__.py:2959
 msgid "This {raidtype}'s timer has already expired as of {expiry_time}!"
 msgstr ""
 
-#: __main__.py:2960
+#: __main__.py:2962
 msgid "This {raidtype} will {raidaction} on {expiry}!"
 msgstr ""
 
-#: __main__.py:2960
 #: __main__.py:2962
-#: __main__.py:3058
+#: __main__.py:2964
 #: __main__.py:3060
-#: __main__.py:4332
+#: __main__.py:3062
+#: __main__.py:4354
 msgid "%B %d at %I:%M %p (%H:%M)"
 msgstr ""
 
-#: __main__.py:2962
+#: __main__.py:2964
 msgid "No one told me when the {raidtype} will {raidaction}, so I'm assuming it will {raidaction} on {expiry}!"
 msgstr ""
 
-#: __main__.py:2964
+#: __main__.py:2966
 msgid "This {raidtype} will {raidaction} at {expiry_time}!"
 msgstr ""
 
-#: __main__.py:2966
+#: __main__.py:2968
 msgid "No one told me when the {raidtype} will {raidaction}, so I'm assuming it will {raidaction} at {expiry_time}!"
 msgstr ""
 
-#: __main__.py:2979
+#: __main__.py:2981
 msgid "Raid Egg"
 msgstr ""
 
-#: __main__.py:2983
+#: __main__.py:2985
 msgid "Raid"
 msgstr ""
 
-#: __main__.py:2996
-#: __main__.py:2999
+#: __main__.py:2998
+#: __main__.py:3001
 msgid "Meowth! I couldn't understand your time format. Try again like this: **!timerset <minutes>**"
 msgstr ""
 
-#: __main__.py:3002
+#: __main__.py:3004
 msgid "Meowth...that's too long. Level {raidlevel} {raidtype}s currently last no more than {maxtime} minutes..."
 msgstr ""
 
-#: __main__.py:3019
-#: __main__.py:3027
+#: __main__.py:3021
+#: __main__.py:3029
 msgid "Meowth! Your timer wasn't formatted correctly. Change your **!timerset** to match this format: **MM/DD HH:MM AM/PM** (You can also omit AM/PM and use 24-hour time!)"
 msgstr ""
 
-#: __main__.py:3034
-#: __main__.py:3128
+#: __main__.py:3036
+#: __main__.py:3130
 msgid "Meowth! Please enter a time in the future."
 msgstr ""
 
-#: __main__.py:3036
+#: __main__.py:3038
 msgid "Meowth! Timerset isn't supported for EX Raids after they have hatched."
 msgstr ""
 
-#: __main__.py:3047
+#: __main__.py:3049
 msgid "The channel has been reactivated."
 msgstr ""
 
-#: __main__.py:3057
+#: __main__.py:3059
 msgid "%B %d at %I:%M %p (%H:%M) | "
 msgstr ""
 
-#: __main__.py:3057
+#: __main__.py:3059
 msgid "Hatches on {expiry}"
 msgstr ""
 
-#: __main__.py:3058
 #: __main__.py:3060
+#: __main__.py:3062
 msgid "Ends on {end}"
 msgstr ""
 
-#: __main__.py:3072
+#: __main__.py:3074
 msgid "Meowth!"
 msgstr ""
 
-#: __main__.py:3111
-#: __main__.py:3117
+#: __main__.py:3113
+#: __main__.py:3119
 msgid "Meowth! Your start time wasn't formatted correctly. Change your **!starttime** to match this format: **HH:MM AM/PM** (You can also omit AM/PM and use 24-hour time!)"
 msgstr ""
 
-#: __main__.py:3125
+#: __main__.py:3127
 msgid "Meowth! The raid will be over before that...."
 msgstr ""
 
-#: __main__.py:3134
+#: __main__.py:3133
+msgid "Meowth! The egg will not hatch by then!"
+msgstr ""
+
+#: __main__.py:3136
 msgid "Meowth! There is already a start time of **{start}** set! Do you want to change it?"
 msgstr ""
 
-#: __main__.py:3139
+#: __main__.py:3141
 msgid "Start time change cancelled."
 msgstr ""
 
-#: __main__.py:3147
-#: __main__.py:3151
+#: __main__.py:3149
+#: __main__.py:3153
 msgid "Meowth! The current start time has been set to: **{starttime}**"
 msgstr ""
 
-#: __main__.py:3158
-#: __main__.py:3162
+#: __main__.py:3160
+#: __main__.py:3164
 msgid "Meowth! No start time has been set, set one with **!starttime HH:MM AM/PM**! (You can also omit AM/PM and use 24-hour time!)"
 msgstr ""
 
-#: __main__.py:3160
+#: __main__.py:3162
 msgid "Meowth! The current start time is: **{starttime}**"
 msgstr ""
 
-#: __main__.py:3186
+#: __main__.py:3188
 msgid ""
 "Meowth! Here's the current location for the raid!\n"
 "Details: {location}\n"
 "Expiry: {topic}"
 msgstr ""
 
-#: __main__.py:3202
+#: __main__.py:3204
 msgid "Meowth! We're missing the new location details! Usage: **!location new <new address>**"
 msgstr ""
 
-#: __main__.py:3257
+#: __main__.py:3260
 msgid "Meowth! I can't recover this channel because I know about it already!"
 msgstr ""
 
-#: __main__.py:3263
+#: __main__.py:3266
 msgid "level-[1-5]-egg"
 msgstr ""
 
-#: __main__.py:3309
+#: __main__.py:3313
 msgid "Ends on %B %d at %I:%M %p"
 msgstr ""
 
-#: __main__.py:3315
-msgid "EX"
-msgstr ""
-
-#: __main__.py:3335
+#: __main__.py:3339
 msgid "Meowth! I couldn't recognize this as a raid channel!"
 msgstr ""
 
-#: __main__.py:3384
+#: __main__.py:3343
+#: __main__.py:3347
+msgid "is interested"
+msgstr ""
+
+#: __main__.py:3343
+#: __main__.py:3349
+msgid "on the way"
+msgstr ""
+
+#: __main__.py:3343
+#: __main__.py:3351
+msgid "at the raid"
+msgstr ""
+
+#: __main__.py:3343
+#: __main__.py:3353
+msgid "left the raid"
+msgstr ""
+
+#: __main__.py:3343
+#: __main__.py:3353
+msgid "no longer"
+msgstr ""
+
+#: __main__.py:3355
+msgid "trainers"
+msgstr ""
+
+#: __main__.py:3404
 msgid "Meowth! This channel has been recovered! However, there may be some inaccuracies in what I remembered! Here's what I have:"
 msgstr ""
 
-#: __main__.py:3394
+#: __main__.py:3416
 msgid ""
 "\n"
 "I'm not sure when this {raidtype} will {action}, so please use **!timerset** if you can!"
 msgstr ""
 
-#: __main__.py:3421
+#: __main__.py:3443
 msgid "Meowth! You've already made a duplicate report for this raid!"
 msgstr ""
 
-#: __main__.py:3442
+#: __main__.py:3464
 msgid "Meowth! Are you sure you wish to remove this raid?"
 msgstr ""
 
-#: __main__.py:3447
+#: __main__.py:3469
 msgid "Duplicate Report cancelled."
 msgstr ""
 
-#: __main__.py:3456
+#: __main__.py:3478
 msgid "Duplicate Confirmed"
 msgstr ""
 
-#: __main__.py:3462
+#: __main__.py:3484
 msgid "Duplicate Report Timed Out."
 msgstr ""
 
-#: __main__.py:3470
+#: __main__.py:3492
 msgid "Duplicate report #{duplicate_report_count} received."
 msgstr ""
 
-#: __main__.py:3572
+#: __main__.py:3520
+#: __main__.py:3543
+#: __main__.py:3594
 msgid "clear"
 msgstr ""
 
-#: __main__.py:3572
+#: __main__.py:3520
+#: __main__.py:3543
+#: __main__.py:3594
 msgid "extreme"
 msgstr ""
 
-#: __main__.py:3572
+#: __main__.py:3520
+#: __main__.py:3543
+#: __main__.py:3594
+msgid "none"
+msgstr ""
+
+#: __main__.py:3520
+#: __main__.py:3543
+#: __main__.py:3594
 msgid "rainy"
 msgstr ""
 
-#: __main__.py:3572
+#: __main__.py:3520
+#: __main__.py:3543
+#: __main__.py:3594
 msgid "sunny"
 msgstr ""
 
-#: __main__.py:3573
+#: __main__.py:3521
+#: __main__.py:3544
+#: __main__.py:3595
 msgid "cloudy"
 msgstr ""
 
-#: __main__.py:3573
+#: __main__.py:3521
+#: __main__.py:3544
+#: __main__.py:3595
 msgid "fog"
 msgstr ""
 
-#: __main__.py:3573
+#: __main__.py:3521
+#: __main__.py:3544
+#: __main__.py:3595
 msgid "partlycloudy"
 msgstr ""
 
-#: __main__.py:3573
+#: __main__.py:3521
+#: __main__.py:3544
+#: __main__.py:3595
 msgid "snow"
 msgstr ""
 
-#: __main__.py:3573
+#: __main__.py:3521
+#: __main__.py:3544
+#: __main__.py:3595
 msgid "windy"
 msgstr ""
 
-#: __main__.py:3575
+#: __main__.py:3539
+msgid "user #{user}'s"
+msgstr ""
+
+#: __main__.py:3542
+msgid "Level 30"
+msgstr ""
+
+#: __main__.py:3569
+msgid ""
+"{pkmn} | {weather}\n"
+msgstr ""
+
+#: __main__.py:3570
+msgid ""
+"**CP:** {raid_cp}\n"
+msgstr ""
+
+#: __main__.py:3571
+msgid ""
+"**Weather:** {weather}\n"
+msgstr ""
+
+#: __main__.py:3572
+msgid "**Attacker Level:** {atk_levels}"
+msgstr ""
+
+#: __main__.py:3576
+msgid "Results courtesy of Pokebattler"
+msgstr ""
+
+#: __main__.py:3581
+msgid "{move1} | {move2}"
+msgstr ""
+
+#: __main__.py:3582
+msgid "#{index} - {ctr_name}"
+msgstr ""
+
+#: __main__.py:3585
+msgid "Results with {userstr} attackers"
+msgstr ""
+
+#: __main__.py:3585
+msgid "[See your personalized results!](https://www.pokebattler.com/raids/{pkmn})"
+msgstr ""
+
+#: __main__.py:3597
 msgid "Meowth! Enter one of the following weather conditions: {}"
 msgstr ""
 
-#: __main__.py:3578
+#: __main__.py:3600
 msgid "Meowth! Weather set to {}!"
 msgstr ""
 
-#: __main__.py:3621
-#: __main__.py:3705
-#: __main__.py:3808
+#: __main__.py:3643
+#: __main__.py:3727
+#: __main__.py:3830
 msgid "{word} doesn't appear in level {egglevel} raids! Please try again."
 msgstr ""
 
-#: __main__.py:3659
+#: __main__.py:3681
 msgid "Meowth! {member} is interested!"
 msgstr ""
 
-#: __main__.py:3661
+#: __main__.py:3683
 msgid "Meowth! {member} is interested with a total of {trainer_count} trainers! {blue_emoji}: {mystic} | {red_emoji}: {valor} | {yellow_emoji}: {instinct} | :grey_question:: {unknown}"
 msgstr ""
 
-#: __main__.py:3712
-#: __main__.py:3815
+#: __main__.py:3734
+#: __main__.py:3837
 msgid "Meowth! Specify which of the possible bosses you are interested in! Otherwise, please wait until the raid egg has hatched before announcing you're coming or present."
 msgstr ""
 
-#: __main__.py:3762
+#: __main__.py:3784
 msgid "Meowth! {member} is on the way!"
 msgstr ""
 
-#: __main__.py:3764
+#: __main__.py:3786
 msgid "Meowth! {member} is on the way with a total of {trainer_count} trainers! {blue_emoji}: {mystic} | {red_emoji}: {valor} | {yellow_emoji}: {instinct} | :grey_question:: {unknown}"
 msgstr ""
 
-#: __main__.py:3852
+#: __main__.py:3874
 msgid ""
 "\n"
 "There is a group already in the lobby! Use **!lobby** to join them or **!backout** to request a backout! Otherwise, you may have to wait for the next group!"
 msgstr ""
 
-#: __main__.py:3870
+#: __main__.py:3892
 msgid "Meowth! {member} is at the raid!"
 msgstr ""
 
-#: __main__.py:3873
+#: __main__.py:3895
 msgid "Meowth! {member} is at the raid with a total of {trainer_count} trainers! {blue_emoji}: {mystic} | {red_emoji}: {valor} | {yellow_emoji}: {instinct} | :grey_question:: {unknown}"
 msgstr ""
 
-#: __main__.py:3934
+#: __main__.py:3956
 msgid "Only one non-team count can be accepted."
 msgstr ""
 
-#: __main__.py:3946
+#: __main__.py:3968
 msgid "Only one count per team accepted."
 msgstr ""
 
-#: __main__.py:3950
+#: __main__.py:3972
 msgid "Invalid format, please check and try again."
 msgstr ""
 
-#: __main__.py:3954
+#: __main__.py:3976
 msgid "Team counts are higher than the total, double check your counts and try again. You entered **"
 msgstr ""
 
-#: __main__.py:3955
+#: __main__.py:3977
 msgid "** total and **"
 msgstr ""
 
-#: __main__.py:3956
+#: __main__.py:3978
 msgid "** in your party."
 msgstr ""
 
-#: __main__.py:3961
+#: __main__.py:3983
 msgid "Meowth! Something is not adding up! Try making sure your total matches what each team adds up to!"
 msgstr ""
 
-#: __main__.py:4017
-msgid "Coordinate here"
-msgstr ""
-
-#: __main__.py:4031
-#: __main__.py:4034
+#: __main__.py:4053
+#: __main__.py:4056
 msgid "**Boss Interest:**"
 msgstr ""
 
-#: __main__.py:4037
+#: __main__.py:4059
 msgid "**Status List**"
 msgstr ""
 
-#: __main__.py:4037
+#: __main__.py:4059
 msgid "Maybe: **{channelmaybe}** | Coming: **{channelcoming}** | Here: **{channelhere}**"
 msgstr ""
 
-#: __main__.py:4038
+#: __main__.py:4060
 msgid "**Team List**"
 msgstr ""
 
-#: __main__.py:4073
+#: __main__.py:4095
 msgid "Meowth! I can't understand how many are in your group. Just say **!here** if you're by yourself, or **!coming 5** for example if there are 5 in your group."
 msgstr ""
 
-#: __main__.py:4083
+#: __main__.py:4105
 msgid "Meowth! There is no group in the lobby for you to join! Use **!starting** if the group waiting at the raid is entering the lobby!"
 msgstr ""
 
-#: __main__.py:4087
+#: __main__.py:4109
 msgid "Meowth! {member} is entering the lobby!"
 msgstr ""
 
-#: __main__.py:4089
+#: __main__.py:4111
 msgid "Meowth! {member} is entering the lobby with a total of {trainer_count} trainers!"
 msgstr ""
 
-#: __main__.py:4113
+#: __main__.py:4135
 msgid "Meowth! {member} has no status to cancel!"
 msgstr ""
 
-#: __main__.py:4117
+#: __main__.py:4139
 msgid "Meowth! {member} is no longer interested!"
 msgstr ""
 
-#: __main__.py:4119
+#: __main__.py:4141
 msgid "Meowth! {member} and their total of {trainer_count} trainers are no longer interested!"
 msgstr ""
 
-#: __main__.py:4122
+#: __main__.py:4144
 msgid "Meowth! {member} has left the raid!"
 msgstr ""
 
-#: __main__.py:4124
+#: __main__.py:4146
 msgid "Meowth! {member} and their total of {trainer_count} trainers have left the raid!"
 msgstr ""
 
-#: __main__.py:4127
+#: __main__.py:4149
 msgid "Meowth! {member} is no longer on their way!"
 msgstr ""
 
-#: __main__.py:4129
+#: __main__.py:4151
 msgid "Meowth! {member} and their total of {trainer_count} trainers are no longer on their way!"
 msgstr ""
 
-#: __main__.py:4132
+#: __main__.py:4154
 msgid "Meowth! {member} has backed out of the lobby!"
 msgstr ""
 
-#: __main__.py:4134
+#: __main__.py:4156
 msgid "Meowth! {member} and their total of {trainer_count} trainers have backed out of the lobby!"
 msgstr ""
 
-#: __main__.py:4160
+#: __main__.py:4182
 msgid "Meowth! How can you start when there's no one waiting at this raid!?"
 msgstr ""
 
-#: __main__.py:4165
+#: __main__.py:4187
 msgid " to start at **{}** "
 msgstr ""
 
-#: __main__.py:4170
+#: __main__.py:4192
 msgid "Meowth! The group that was waiting{timestr}is starting the raid! Trainers {trainer_list}, if you are not in this group and are waiting for the next group, please respond with {here_emoji} or **!here**. If you need to ask those that just started to back out of their lobby, use **!backout**"
 msgstr ""
 
-#: __main__.py:4185
+#: __main__.py:4207
 msgid "Meowth! The group of {count} in the lobby has entered the raid! Wish them luck!"
 msgstr ""
 
-#: __main__.py:4216
+#: __main__.py:4238
 msgid "Meowth! There's no one else in the lobby for this raid!"
 msgstr ""
 
-#: __main__.py:4222
+#: __main__.py:4244
 msgid "Meowth! {author} has indicated that the group consisting of {lobby_list} and the people with them has backed out of the lobby! If this is inaccurate, please use **!lobby** or **!cancel** to help me keep my lists accurate!"
 msgstr ""
 
-#: __main__.py:4236
+#: __main__.py:4258
 msgid "Meowth! There's no one in the lobby for this raid!"
 msgstr ""
 
-#: __main__.py:4238
+#: __main__.py:4260
 msgid "Meowth! {author} has requested a backout! If one of the following trainers reacts with the check mark, I will assume the group is backing out of the raid lobby as requested! {lobby_list}"
 msgstr ""
 
-#: __main__.py:4251
+#: __main__.py:4273
 msgid "Meowth! {user} confirmed the group is backing out!"
 msgstr ""
 
-#: __main__.py:4269
-#: __main__.py:4624
+#: __main__.py:4291
+#: __main__.py:4646
 msgid "**Meowth!** "
 msgstr ""
 
-#: __main__.py:4319
+#: __main__.py:4341
 msgid " (assumed)"
 msgstr ""
 
-#: __main__.py:4325
+#: __main__.py:4347
 msgid " Next group: **{}**"
 msgstr ""
 
-#: __main__.py:4330
-#: __main__.py:4332
+#: __main__.py:4352
+#: __main__.py:4354
 msgid " - Hatches: {expiry}{is_assumed}"
 msgstr ""
 
-#: __main__.py:4334
+#: __main__.py:4356
 msgid " - Expiry: {expiry}{is_assumed}"
 msgstr ""
 
-#: __main__.py:4335
+#: __main__.py:4357
 msgid ""
 "    {raidchannel}{expiry_text}\n"
 msgstr ""
 
-#: __main__.py:4336
+#: __main__.py:4358
 msgid ""
 "    {interestcount} interested, {comingcount} coming, {herecount} here, {lobbycount} in the lobby.{start_str}\n"
 msgstr ""
 
-#: __main__.py:4339
+#: __main__.py:4361
 msgid ""
 "**Here's the current raids for {0}**\n"
 "\n"
 msgstr ""
 
-#: __main__.py:4341
+#: __main__.py:4363
 msgid ""
 "**Active Raids:**\n"
 msgstr ""
 
-#: __main__.py:4346
+#: __main__.py:4368
 msgid ""
 "**Raid Eggs:**\n"
 msgstr ""
 
-#: __main__.py:4351
+#: __main__.py:4373
 msgid ""
 "**EX Raids:**\n"
 msgstr ""
 
-#: __main__.py:4355
+#: __main__.py:4377
 msgid "Meowth! No active raids! Report one with **!raid <name> <location>**."
 msgstr ""
 
-#: __main__.py:4378
+#: __main__.py:4400
 msgid " Nobody has updated their status yet!"
 msgstr ""
 
-#: __main__.py:4381
-#: __main__.py:4646
+#: __main__.py:4403
+#: __main__.py:4668
 msgid ""
 "\n"
 "The next group will be starting at **{}**"
 msgstr ""
 
-#: __main__.py:4394
-#: __main__.py:4430
-#: __main__.py:4466
-#: __main__.py:4502
-#: __main__.py:4535
-#: __main__.py:4577
-#: __main__.py:4656
+#: __main__.py:4416
+#: __main__.py:4452
+#: __main__.py:4488
+#: __main__.py:4524
+#: __main__.py:4557
+#: __main__.py:4599
+#: __main__.py:4678
 msgid "**Meowth!**"
 msgstr ""
 
-#: __main__.py:4417
-#: __main__.py:4419
+#: __main__.py:4439
+#: __main__.py:4441
 msgid " including {trainer_list} and the people with them! Let them know if there is a group forming"
 msgstr ""
 
-#: __main__.py:4420
+#: __main__.py:4442
 msgid " {trainer_count} interested{including_string}!"
 msgstr ""
 
-#: __main__.py:4453
-#: __main__.py:4455
+#: __main__.py:4475
+#: __main__.py:4477
 msgid " including {trainer_list} and the people with them! Be considerate and wait for them if possible"
 msgstr ""
 
-#: __main__.py:4456
+#: __main__.py:4478
 msgid " {trainer_count} on the way{including_string}!"
 msgstr ""
 
-#: __main__.py:4489
-#: __main__.py:4491
+#: __main__.py:4511
+#: __main__.py:4513
 msgid " including {trainer_list} and the people with them! Be considerate and let them know if and when you'll be there"
 msgstr ""
 
-#: __main__.py:4492
+#: __main__.py:4514
 msgid " {trainer_count} waiting at the raid{including_string}!"
 msgstr ""
 
-#: __main__.py:4525
-#: __main__.py:4527
+#: __main__.py:4547
+#: __main__.py:4549
 msgid " including {trainer_list} and the people with them! Use **!lobby** if you are joining them or **!backout** to request a backout"
 msgstr ""
 
-#: __main__.py:4528
+#: __main__.py:4550
 msgid " {trainer_count} in the lobby{including_string}!"
 msgstr ""
 
-#: __main__.py:4568
+#: __main__.py:4588
+msgid ""
+"{type}{name}: **{total} total,** {interested} interested, {coming} coming, {waiting} waiting{type}\n"
+msgstr ""
+
+#: __main__.py:4590
 msgid ""
 " Boss numbers for the raid:\n"
 "{}"
 msgstr ""
 
-#: __main__.py:4570
+#: __main__.py:4592
 msgid " Nobody has told me what boss they want!"
 msgstr ""
 
-#: __main__.py:4606
+#: __main__.py:4625
+msgid ""
+"{emoji} **{total} total,** {interested} interested, {coming} coming, {waiting} waiting {emoji}\n"
+msgstr ""
+
+#: __main__.py:4628
 msgid "**{grey_number} total,** {greymaybe} interested, {greycoming} coming, {greywaiting} waiting"
 msgstr ""
 
-#: __main__.py:4610
+#: __main__.py:4632
 msgid ""
 " Team numbers for the raid:\n"
 "{}"
 msgstr ""
 
-#: __main__.py:4612
+#: __main__.py:4634
 msgid " Nobody has updated their status!"
 msgstr ""
 
-#: __main__.py:4666
+#: __main__.py:4688
 msgid " Your current **!want** list is: ```{wantlist}```"
 msgstr ""
 
-#: __main__.py:4668
+#: __main__.py:4690
 msgid " You don't have any wants! use **!want** to add some."
 msgstr ""
 
-####################### MAIN END - ERRORS BEGIN #######################
+#: MAIN END ------------- ERRORS BEGINS
 
 #: errors.py:81
 msgid "Meowth! I'm missing some details! Usage: {prefix}{command}"
@@ -1847,18 +2010,18 @@ msgid "Meowth! Please use **!{cmd_name}** in "
 msgstr ""
 
 #: errors.py:129
-#: errors.py:202
-#: errors.py:215
-#: errors.py:228
-#: errors.py:241
+#: errors.py:209
+#: errors.py:222
+#: errors.py:235
+#: errors.py:248
 msgid "a Region report channel."
 msgstr ""
 
 #: errors.py:131
-#: errors.py:204
-#: errors.py:217
-#: errors.py:230
-#: errors.py:243
+#: errors.py:211
+#: errors.py:224
+#: errors.py:237
+#: errors.py:250
 msgid "one of the following region channels:"
 msgstr ""
 
@@ -1881,13 +2044,13 @@ msgstr ""
 
 #: errors.py:159
 #: errors.py:172
-#: errors.py:189
+#: errors.py:194
 msgid "Region report channel to see active raids."
 msgstr ""
 
 #: errors.py:161
 #: errors.py:174
-#: errors.py:191
+#: errors.py:196
 msgid "of the following Region channels to see active raids:"
 msgstr ""
 
@@ -1903,18 +2066,24 @@ msgstr ""
 msgid "Meowth! Please use **!{cmd_name}** in an Active Raid channel. Use **!list** in any "
 msgstr ""
 
-#: errors.py:199
+#: errors.py:201
+msgid ""
+"\n"
+"This is an egg channel. The channel needs to be activated with **!raid <pokemon>** before I accept commands!"
+msgstr ""
+
+#: errors.py:206
 msgid "Meowth! Please use **!{cmd_name}** in either a Raid channel or "
 msgstr ""
 
-#: errors.py:212
+#: errors.py:219
 msgid "Meowth! Please use **!{cmd_name}** in either a Raid Egg channel or "
 msgstr ""
 
-#: errors.py:225
+#: errors.py:232
 msgid "Meowth! Please use **!{cmd_name}** in either a EX Raid channel or one of the following region channels:"
 msgstr ""
 
-#: errors.py:238
+#: errors.py:245
 msgid "Meowth! Please use **!{cmd_name}** in a EX Raid channel. Use **!list** in any of the following region channels to see active raids:"
 msgstr ""

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -1754,7 +1754,8 @@ async def changeraid(ctx, newraid):
         await channel.send(_('The channel you entered is not a raid channel.'))
         return
     if newraid.isdigit() and (guild_dict[guild.id]['raidchannel_dict'][channel.id]['type'] == 'egg'):
-        raid_channel_name = (('level-' + newraid) + '-egg-') + sanitize_channel_name(guild_dict[guild.id]['raidchannel_dict'][channel.id]['address'])
+        raid_channel_name = _('level-{egg_level}-egg-').format(egg_level=newraid)
+        raid_channel_name += sanitize_channel_name(guild_dict[guild.id]['raidchannel_dict'][channel.id]['address'])
         guild_dict[guild.id]['raidchannel_dict'][channel.id]['egglevel'] = newraid
         guild_dict[guild.id]['raidchannel_dict'][channel.id]['pokemon'] = ''
         egg_img = raid_info['raid_eggs'][newraid]['egg_img']
@@ -1782,8 +1783,8 @@ async def changeraid(ctx, newraid):
             s = _('status')
             if (t in field.name.lower()) or (s in field.name.lower()):
                 raid_embed.add_field(name=field.name, value=field.value, inline=field.inline)
-        raid_message.content = re.sub('level\s\d', 'Level {}'.format(newraid), raid_message.content, flags=re.IGNORECASE)
-        report_message.content = re.sub('level\s\d', 'Level {}'.format(newraid), report_message.content, flags=re.IGNORECASE)
+        raid_message.content = re.sub(_('level\s\d'), _('Level {}').format(newraid), raid_message.content, flags=re.IGNORECASE)
+        report_message.content = re.sub(_('level\s\d'), _('Level {}').format(newraid), report_message.content, flags=re.IGNORECASE)
         await raid_message.edit(new_content=raid_message.content, embed=raid_embed, content=raid_message.content)
         try:
             await report_message.edit(new_content=report_message.content, embed=raid_embed, content=report_message.content)
@@ -1813,7 +1814,7 @@ async def clearstatus(ctx):
         return
     try:
         guild_dict[ctx.guild.id]['raidchannel_dict'][ctx.channel.id]['trainer_dict'] = {}
-        await ctx.channel.send('Meowth! Raid status lists have been cleared!')
+        await ctx.channel.send(_('Meowth! Raid status lists have been cleared!'))
     except KeyError:
         pass
 
@@ -1861,7 +1862,7 @@ async def cmd_uptime(ctx):
     try:
         await channel.send(embed=embed)
     except discord.HTTPException:
-        await channel.send('I need the `Embed links` permission to send this')
+        await channel.send(_('I need the `Embed links` permission to send this'))
 
 async def _uptime(bot):
     'Shows info about Meowth'
@@ -1870,15 +1871,15 @@ async def _uptime(bot):
     ut = relativedelta(time_now, time_start)
     (ut.years, ut.months, ut.days, ut.hours, ut.minutes)
     if ut.years >= 1:
-        uptime = '{yr}y {mth}m {day}d {hr}:{min}'.format(yr=ut.years, mth=ut.months, day=ut.days, hr=ut.hours, min=ut.minutes)
+        uptime = _('{yr}y {mth}m {day}d {hr}:{min}').format(yr=ut.years, mth=ut.months, day=ut.days, hr=ut.hours, min=ut.minutes)
     elif ut.months >= 1:
-        uptime = '{mth}m {day}d {hr}:{min}'.format(mth=ut.months, day=ut.days, hr=ut.hours, min=ut.minutes)
+        uptime = _('{mth}m {day}d {hr}:{min}').format(mth=ut.months, day=ut.days, hr=ut.hours, min=ut.minutes)
     elif ut.days >= 1:
-        uptime = '{day} days {hr} hrs {min} mins'.format(day=ut.days, hr=ut.hours, min=ut.minutes)
+        uptime = _('{day} days {hr} hrs {min} mins').format(day=ut.days, hr=ut.hours, min=ut.minutes)
     elif ut.hours >= 1:
-        uptime = '{hr} hrs {min} mins {sec} secs'.format(hr=ut.hours, min=ut.minutes, sec=ut.seconds)
+        uptime = _('{hr} hrs {min} mins {sec} secs').format(hr=ut.hours, min=ut.minutes, sec=ut.seconds)
     else:
-        uptime = '{min} mins {sec} secs'.format(min=ut.minutes, sec=ut.seconds)
+        uptime = _('{min} mins {sec} secs').format(min=ut.minutes, sec=ut.seconds)
     return uptime
 
 @Meowth.command()
@@ -1894,7 +1895,7 @@ async def about(ctx):
     yourserver = ctx.message.guild.name
     yourmembers = len(ctx.message.guild.members)
     embed_colour = ctx.guild.me.colour or discord.Colour.lighter_grey()
-    about = "I'm Meowth! A Pokemon Go helper bot for Discord!\n\nI'm made by [{author_name}]({author_repo}) and improvements have been contributed by many other people also.\n\n[Join our server]({server_invite}) if you have any questions or feedback.\n\n".format(author_name=author_name, author_repo=author_repo, server_invite=guild_url)
+    about = _("I'm Meowth! A Pokemon Go helper bot for Discord!\n\nI'm made by [{author_name}]({author_repo}) and improvements have been contributed by many other people also.\n\n[Join our server]({server_invite}) if you have any questions or feedback.\n\n").format(author_name=author_name, author_repo=author_repo, server_invite=guild_url)
     member_count = 0
     guild_count = 0
     for guild in Meowth.guilds:
@@ -1913,7 +1914,7 @@ async def about(ctx):
     try:
         await channel.send(embed=embed)
     except discord.HTTPException:
-        await channel.send('I need the `Embed links` permission to send this')
+        await channel.send(_('I need the `Embed links` permission to send this'))
 
 @Meowth.command()
 @checks.teamset()
@@ -1926,7 +1927,7 @@ async def team(ctx):
     guild = ctx.guild
     toprole = guild.me.top_role.name
     position = guild.me.top_role.position
-    team_msg = ' or '.join(['**!team {0}**'.format(team) for team in config['team_dict'].keys()])
+    team_msg = _(' or ').join(['**!team {0}**'.format(team) for team in config['team_dict'].keys()])
     high_roles = []
     guild_roles = []
     lowercase_roles = []
@@ -2669,7 +2670,8 @@ async def _eggtoraid(entered_raid, raid_channel, author=None):
     if not reportcitychannel:
         async for message in raid_channel.history(limit=500, reverse=True):
             if message.author.id == guild.me.id:
-                if 'Coordinate here' in message.content:
+                c = _('Coordinate here')
+                if c in message.content:
                     reportcitychannel = message.raw_channel_mentions[0]
                     break
     if reportcitychannel:
@@ -3128,7 +3130,7 @@ async def starttime(ctx):
             await channel.send(_('Meowth! Please enter a time in the future.'))
             return
         if int(total) < int(mintime):
-            await channel.send('Meowth! The egg will not hatch by then!')
+            await channel.send(_('Meowth! The egg will not hatch by then!'))
             return
         if alreadyset:
             rusure = await channel.send(_('Meowth! There is already a start time of **{start}** set! Do you want to change it?').format(start=alreadyset.strftime(_('%I:%M %p (%H:%M)'))))
@@ -3206,7 +3208,8 @@ async def new(ctx):
         if not report_channel:
             async for m in message.channel.history(limit=500, reverse=True):
                 if m.author.id == guild.me.id:
-                    if 'Coordinate here' in m.content:
+                    c = _('Coordinate here')
+                    if c in message.content:
                         report_channel = m.raw_channel_mentions[0]
                         break
         report_city = report_channel.name
@@ -3269,12 +3272,13 @@ async def recover(ctx):
         }
         async for message in channel.history(limit=500, reverse=True):
             if message.author.id == guild.me.id:
-                if 'Coordinate here' in message.content:
+                c = _('Coordinate here')
+                if c in message.content:
                     reportchannel = message.raw_channel_mentions[0]
                     raidmessage = message
                     break
         if egg:
-            raidtype = _('egg')
+            raidtype = 'egg'
             chsplit = egg.string.split('-')
             del chsplit[0]
             egglevel = chsplit[0]
@@ -3295,7 +3299,7 @@ async def recover(ctx):
             if len(raid_info['raid_eggs'][egglevel]['pokemon']) == 1:
                 pokemon = get_name(raid_info['raid_eggs'][egglevel]['pokemon'][0])
         elif name.split('-')[0] in get_raidlist():
-            raidtype = _('raid')
+            raidtype = 'raid'
             egglevel = '0'
             chsplit = name.split('-')
             pokemon = chsplit[0]
@@ -3311,8 +3315,8 @@ async def recover(ctx):
                 exp = utcend.replace(year=now.year, tzinfo=datetime.timezone.utc).timestamp()
                 manual_timer = True
         elif name.split('-')[0] == 'ex':
-            raidtype = _('egg')
-            egglevel = _('EX')
+            raidtype = 'egg'
+            egglevel = 'EX'
             chsplit = name.split('-')
             del chsplit[0]
             del chsplit[0]
@@ -3336,19 +3340,19 @@ async def recover(ctx):
             return
         async for message in channel.history(limit=500):
             if message.author.id == guild.me.id:
-                if ('is interested' in message.content) or ('on the way' in message.content) or ('at the raid' in message.content) or ('no longer' in message.content) or ('left the raid' in message.content):
+                if (_('is interested') in message.content) or (_('on the way') in message.content) or (_('at the raid') in message.content) or (_('no longer') in message.content) or (_('left the raid') in message.content):
                     if message.raw_mentions:
                         if message.raw_mentions[0] not in trainer_dict:
                             trainerid = message.raw_mentions[0]
-                            if 'is interested' in message.content:
+                            if _('is interested') in message.content:
                                 status = 'maybe'
-                            if 'on the way' in message.content:
+                            if _('on the way') in message.content:
                                 status = 'omw'
-                            if 'at the raid' in message.content:
+                            if _('at the raid') in message.content:
                                 status = 'waiting'
-                            if ('no longer' in message.content) or ('left the raid' in message.content):
+                            if (_('no longer') in message.content) or (_('left the raid') in message.content):
                                 status = None
-                            if 'trainers' in message.content:
+                            if _('trainers') in message.content:
                                 messagesplit = message.content.split()
                                 if messagesplit[(- 2)].isdigit():
                                     count = int(messagesplit[(- 2)])
@@ -3356,13 +3360,27 @@ async def recover(ctx):
                                     count = 1
                                 if messagesplit[-1].isdigit():
                                     party = [int(messagesplit[-10]),int(messagesplit[-7]),int(messagesplit[-4]),int(messagesplit[-1])]
+                                    count = int(messagesplit[-10]) + int(messagesplit[-7]) + int(messagesplit[-4]) + int(messagesplit[-1])
                                 else:
                                     party = [0,0,0,count]
                             else:
                                 count = 1
+                                for role in message.raw_mentions.roles:
+                                    if role.name.lower() == 'mystic':
+                                        party = [1,0,0,0]
+                                        break
+                                    elif role.name.lower() == 'valor':
+                                        party = [0,1,0,0]
+                                        break
+                                    elif role.name.lower() == 'instinct':
+                                        party = [0,0,1,0]
+                                        break
+                                    else:
+                                        party = [0,0,0,1]
                             trainer_dict[trainerid] = {
                                 'status': status,
                                 'count': count,
+                                'party': party,
                             }
                         else:
                             continue
@@ -3381,17 +3399,21 @@ async def recover(ctx):
             'pokemon': pokemon,
             'egglevel': egglevel,
         }
+        for trainerid in guild_dict[channel.guild.id]['raidchannel_dict'][channel.id]['trainer_dict']:
+            await _edit_party(channel, Meowth.get_user_info(trainerid))
         recovermsg = _("Meowth! This channel has been recovered! However, there may be some inaccuracies in what I remembered! Here's what I have:")
         bulletpoint = parse_emoji(ctx.guild, ':small_blue_diamond:')
         recovermsg += ('\n' + bulletpoint) + (await _interest(ctx))
         recovermsg += ('\n' + bulletpoint) + (await _otw(ctx))
         recovermsg += ('\n' + bulletpoint) + (await _waiting(ctx))
         if (not manual_timer):
-            if raidtype == _('egg'):
+            if raidtype == 'egg':
                 action = _('hatch')
-            elif raidtype == _('raid'):
+                type = _('egg')
+            elif raidtype == 'raid':
                 action = _('end')
-            recovermsg += _("\nI'm not sure when this {raidtype} will {action}, so please use **!timerset** if you can!").format(raidtype=raidtype, action=action)
+                type = _('raid')
+            recovermsg += _("\nI'm not sure when this {raidtype} will {action}, so please use **!timerset** if you can!").format(raidtype=type, action=action)
         else:
             recovermsg += ('\n' + bulletpoint) + (await print_raid_timer(channel))
         await channel.send(recovermsg)
@@ -3495,8 +3517,8 @@ async def counters(ctx, *, args = None):
         pkmn = next((str(p) for p in get_raidlist() if not str(p).isdigit() and re.sub(rgx, '', str(p)) in re.sub(rgx, '', args.lower())), None)
         if not pkmn:
             pkmn = guild_dict[guild.id]['raidchannel_dict'][channel.id].get('pokemon', None)
-        weather_list = ['none', 'extreme', 'clear', 'sunny', 'rainy',
-                        'partlycloudy', 'cloudy', 'windy', 'snow', 'fog']
+        weather_list = [_('none'), _('extreme'), _('clear'), _('sunny'), _('rainy'),
+                        _('partlycloudy'), _('cloudy'), _('windy'), _('snow'), _('fog')]
         weather = next((w for w in weather_list if re.sub(rgx, '', w) in re.sub(rgx, '', args.lower())), None)
     else:
         pkmn = guild_dict[guild.id]['raidchannel_dict'][channel.id].get('pokemon', None)
@@ -3514,19 +3536,19 @@ async def _counters(ctx, pkmn, user = None, weather = None):
     url = "https://fight.pokebattler.com/raids/defenders/{pkmn}/levels/RAID_LEVEL_{level}/attackers/".format(pkmn=pkmn.replace('-','_').upper(),level=level)
     if user:
         url += "users/{user}/".format(user=user)
-        userstr = "user #{user}'s".format(user=user)
+        userstr = _("user #{user}'s").format(user=user)
     else:
         url += "levels/30/"
-        userstr = "Level 30"
-    if not weather:
-        weather = "NO_WEATHER"
-    else:
-        weather_list = ['none', 'extreme', 'clear', 'sunny', 'rainy',
-                        'partlycloudy', 'cloudy', 'windy', 'snow', 'fog']
-        match_list = ['NO_WEATHER','NO_WEATHER','CLEAR','CLEAR','RAINY',
+        userstr = _("Level 30")
+    weather_list = [_('none'), _('extreme'), _('clear'), _('sunny'), _('rainy'),
+                    _('partlycloudy'), _('cloudy'), _('windy'), _('snow'), _('fog')]
+    match_list = ['NO_WEATHER','NO_WEATHER','CLEAR','CLEAR','RAINY',
                         'PARTLY_CLOUDY','OVERCAST','WINDY','SNOW','FOG']
+    if not weather:
+        index = 0
+    else:
         index = weather_list.index(weather)
-        weather = match_list[index]
+    weather = match_list[index]
     url += "strategies/CINEMATIC_ATTACK_WHEN_POSSIBLE/DEFENSE_RANDOM_MC?sort=OVERALL&"
     url += "weatherCondition={weather}&dodgeStrategy=DODGE_REACTION_TIME&aggregation=AVERAGE".format(weather=weather)
     async with ctx.typing():
@@ -3542,25 +3564,24 @@ async def _counters(ctx, pkmn, user = None, weather = None):
         raid_cp = data['cp']
         atk_levels = '30'
         ctrs = data['randomMove']['defenders'][-6:]
-        index = 1
         def clean(txt):
             return txt.replace('_', ' ').title()
-        title = '{pkmn} | {weather}'.format(pkmn=pkmn.title(),weather=clean(weather))
-        stats_msg = "**CP:** {raid_cp}\n".format(raid_cp=raid_cp)
-        stats_msg += "**Weather:** {weather}\n".format(weather=clean(weather))
-        stats_msg += "**Attacker Level:** {atk_levels}".format(atk_levels=atk_levels)
+        stats_msg = _("**CP:** {raid_cp}\n").format(raid_cp=raid_cp)
+        stats_msg += _("**Weather:** {weather}\n").format(weather=clean(weather))
+        stats_msg += _("**Attacker Level:** {atk_levels}").format(atk_levels=atk_levels)
         ctrs_embed = discord.Embed(colour=colour)
         ctrs_embed.set_author(name=title,url=title_url,icon_url=hyperlink_icon)
         ctrs_embed.set_thumbnail(url=img_url)
-        ctrs_embed.set_footer(text='Results courtesy of Pokebattler', icon_url=pbtlr_icon)
+        ctrs_embed.set_footer(text=_('Results courtesy of Pokebattler'), icon_url=pbtlr_icon)
+        index = 1
         for ctr in reversed(ctrs):
             ctr_name = clean(ctr['pokemonId'])
             moveset = ctr['byMove'][-1]
-            moves = "{move1} | {move2}".format(move1=clean(moveset['move1'])[:-5], move2=clean(moveset['move2']))
-            name = "#{index} - {ctr_name}".format(index=index, ctr_name=ctr_name)
+            moves = _("{move1} | {move2}").format(move1=clean(moveset['move1'])[:-5], move2=clean(moveset['move2']))
+            name = _("#{index} - {ctr_name}").format(index=index, ctr_name=ctr_name)
             ctrs_embed.add_field(name=name,value=moves)
             index += 1
-        ctrs_embed.add_field(name="Results with {userstr} attackers".format(userstr=userstr), value="[See your personalized results!](https://www.pokebattler.com/raids/{pkmn})".format(pkmn=pkmn.replace('-','_').upper()))
+        ctrs_embed.add_field(name=_("Results with {userstr} attackers").format(userstr=userstr), value=_("[See your personalized results!](https://www.pokebattler.com/raids/{pkmn})").format(pkmn=pkmn.replace('-','_').upper()))
         await ctx.channel.send(embed=ctrs_embed)
 
 
@@ -3569,7 +3590,7 @@ async def _counters(ctx, pkmn, user = None, weather = None):
 @checks.activeraidchannel()
 async def weather(ctx, *, weather):
     "Sets the weather for the raid. \nUsage: !weather <weather> \nOnly usable in raid channels. \n Acceptable options: none, extreme, clear, rainy, partlycloudy, cloudy, windy, snow, fog"
-    weather_list = ['none', _('extreme'), _('clear'), _('sunny'), _('rainy'),
+    weather_list = [_('none'), _('extreme'), _('clear'), _('sunny'), _('rainy'),
                     _('partlycloudy'), _('cloudy'), _('windy'), _('snow'), _('fog')]
     if weather.lower() not in weather_list:
         return await ctx.channel.send(_("Meowth! Enter one of the following weather conditions: {}").format(", ".join(weather_list)))
@@ -3600,7 +3621,7 @@ async def interested(ctx, *, teamcounts: str=None):
             bluecount = str(trainer_dict[ctx.author.id]['party'][0]) + 'm '
             redcount = str(trainer_dict[ctx.author.id]['party'][1]) + 'v '
             yellowcount = str(trainer_dict[ctx.author.id]['party'][2]) + 'i '
-            unknowncount = str(trainer_dict[ctx.author.id]['party'][3]) + 'i '
+            unknowncount = str(trainer_dict[ctx.author.id]['party'][3]) + 'u '
             teamcounts = ((((str(trainer_dict[ctx.author.id]['count']) + ' ') + bluecount) + redcount) + yellowcount) + unknowncount
         else:
             teamcounts = '1'
@@ -3623,7 +3644,7 @@ async def interested(ctx, *, teamcounts: str=None):
                 teamcounts = teamcounts.lower().replace(word.lower(),"").replace(",","").strip()
     if teamcounts and teamcounts.split()[0].isdigit():
         total = int(teamcounts.split()[0])
-    elif ctx.author.id in trainer_dict:
+    elif (ctx.author.id in trainer_dict) and (trainer_dict[ctx.author.id]['status'] != None):
         total = trainer_dict[ctx.author.id]['count']
     elif teamcounts:
         total = sum([int(s) for s in teamcounts if s.isdigit()])
@@ -3867,11 +3888,11 @@ async def _here(channel, author, count, party, entered_interest=None):
             allunknown = count
         party = [allblue, allred, allyellow, allunknown]
     if count == 1:
-        msg = _('Meowth! {member} is at the raid!')
-        await channel.send((msg + lobbymsg).format(member=author.mention))
+        msg = _('Meowth! {member} is at the raid!').format(member=author.mention)
+        await channel.send(msg + lobbymsg)
     else:
-        msg = _('Meowth! {member} is at the raid with a total of {trainer_count} trainers! {blue_emoji}: {mystic} | {red_emoji}: {valor} | {yellow_emoji}: {instinct} | :grey_question:: {unknown}')
-        await channel.send(msg + lobbymsg).format(member=author.mention, trainer_count=count, blue_emoji=parse_emoji(channel.guild, config['team_dict']['mystic']), mystic=party[0], red_emoji=parse_emoji(channel.guild, config['team_dict']['valor']), valor=party[1], instinct=party[2], yellow_emoji=parse_emoji(channel.guild, config['team_dict']['instinct']), unknown=party[3])
+        msg = _('Meowth! {member} is at the raid with a total of {trainer_count} trainers! {blue_emoji}: {mystic} | {red_emoji}: {valor} | {yellow_emoji}: {instinct} | :grey_question:: {unknown}').format(member=author.mention, trainer_count=count, blue_emoji=parse_emoji(channel.guild, config['team_dict']['mystic']), mystic=party[0], red_emoji=parse_emoji(channel.guild, config['team_dict']['valor']), valor=party[1], instinct=party[2], yellow_emoji=parse_emoji(channel.guild, config['team_dict']['instinct']), unknown=party[3])
+        await channel.send(msg + lobbymsg)
     if author.id not in trainer_dict:
         trainer_dict[author.id] = {
 
@@ -4028,10 +4049,10 @@ async def _edit_party(channel, author=None):
             newembed.add_field(name=field.name, value=field.value, inline=field.inline)
     if egglevel != "0":
         if len(boss_list) > 1:
-            newembed.set_field_at(0, name=_("**Boss Interest:**") if channel_dict["boss"] > 0 else "**Possible Bosses:**", value=_('{bosslist1}').format(bosslist1='\n'.join(display_list[::2])), inline=True)
+            newembed.set_field_at(0, name=_("**Boss Interest:**") if channel_dict["boss"] > 0 else _("**Possible Bosses:**"), value=_('{bosslist1}').format(bosslist1='\n'.join(display_list[::2])), inline=True)
             newembed.set_field_at(1, name='\u200b', value=_('{bosslist2}').format(bosslist2='\n'.join(display_list[1::2])), inline=True)
         else:
-            newembed.set_field_at(0, name=_("**Boss Interest:**") if channel_dict["boss"] > 0 else "**Possible Bosses:**", value=_('{bosslist}').format(bosslist=''.join(display_list)), inline=True)
+            newembed.set_field_at(0, name=_("**Boss Interest:**") if channel_dict["boss"] > 0 else _("**Possible Bosses:**"), value=_('{bosslist}').format(bosslist=''.join(display_list)), inline=True)
             newembed.set_field_at(1, name='\u200b', value='\u200b', inline=True)
     if channel_dict["total"] > 0:
         newembed.add_field(name=_('**Status List**'), value=_('Maybe: **{channelmaybe}** | Coming: **{channelcoming}** | Here: **{channelhere}**').format(channelmaybe=channel_dict["maybe"], channelcoming=channel_dict["omw"], channelhere=channel_dict["waiting"]), inline=True)
@@ -4563,7 +4584,7 @@ async def _bosslist(ctx):
     bossliststr = ''
     for boss in boss_list:
         if boss_dict[boss]['total'] > 0:
-            bossliststr += '{type}{name}: **{total} total,** {interested} interested, {coming} coming, {waiting} waiting{type}\n'.format(type=boss_dict[boss]['type'],name=boss.capitalize(), total=boss_dict[boss]['total'], interested=boss_dict[boss]['maybe'], coming=boss_dict[boss]['omw'], waiting=boss_dict[boss]['waiting'])
+            bossliststr += _('{type}{name}: **{total} total,** {interested} interested, {coming} coming, {waiting} waiting{type}\n').format(type=boss_dict[boss]['type'],name=boss.capitalize(), total=boss_dict[boss]['total'], interested=boss_dict[boss]['maybe'], coming=boss_dict[boss]['omw'], waiting=boss_dict[boss]['waiting'])
     if bossliststr:
         listmsg = _(' Boss numbers for the raid:\n{}').format(bossliststr)
     else:
@@ -4600,7 +4621,7 @@ async def _teamlist(ctx):
         index = 0
     for team in team_list[:-1]:
         if team_dict[team]['total'] > 0:
-            teamliststr += '{emoji} **{total} total,** {interested} interested, {coming} coming, {waiting} waiting {emoji}\n'.format(emoji=parse_emoji(ctx.guild, config['team_dict'][team]), total=team_dict[team]['total'], interested=team_dict[team]['maybe'], coming=team_dict[team]['omw'], waiting=team_dict[team]['waiting'])
+            teamliststr += _('{emoji} **{total} total,** {interested} interested, {coming} coming, {waiting} waiting {emoji}\n').format(emoji=parse_emoji(ctx.guild, config['team_dict'][team]), total=team_dict[team]['total'], interested=team_dict[team]['maybe'], coming=team_dict[team]['omw'], waiting=team_dict[team]['waiting'])
     if team_dict["unknown"]['total'] > 0:
         teamliststr += '❔ '
         teamliststr += _('**{grey_number} total,** {greymaybe} interested, {greycoming} coming, {greywaiting} waiting')

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -1277,7 +1277,7 @@ async def configure(ctx):
                                  "**{&role}** - Replace role name or ID (shows as @deleted-role DM preview)\n"
                                  "**{user}** - Will mention the new user\n"
                                  "**{server}** - Will print your server's name\n"
-                                 "Surround your message with [] to send it as an embed. **Warning:** Mentions within embeds may be broken on mobile, this is a Discord bug."))).set_author(name="Welcome Message", icon_url=Meowth.user.avatar_url))
+                                 "Surround your message with [] to send it as an embed. **Warning:** Mentions within embeds may be broken on mobile, this is a Discord bug."))).set_author(name=_("Welcome Message"), icon_url=Meowth.user.avatar_url))
                 while True:
                     welcomemsgreply = await Meowth.wait_for('message', check=(lambda message: (message.guild == None) and (message.author == owner)))
                     if welcomemsgreply.content.lower() == 'n':
@@ -1902,15 +1902,15 @@ async def about(ctx):
         guild_count += 1
         member_count += len(guild.members)
     embed = discord.Embed(colour=embed_colour, icon_url=Meowth.user.avatar_url)
-    embed.add_field(name='About Meowth', value=about, inline=False)
-    embed.add_field(name='Owner', value=owner)
+    embed.add_field(name=_('About Meowth'), value=about, inline=False)
+    embed.add_field(name=_('Owner'), value=owner)
     if guild_count > 1:
-        embed.add_field(name='Servers', value=guild_count)
-        embed.add_field(name='Members', value=member_count)
-    embed.add_field(name="Your Server", value=yourserver)
-    embed.add_field(name="Your Members", value=yourmembers)
-    embed.add_field(name='Uptime', value=uptime_str)
-    embed.set_footer(text='For support, contact us on our Discord server. Invite Code: hhVjAN8')
+        embed.add_field(name=_('Servers'), value=guild_count)
+        embed.add_field(name=_('Members'), value=member_count)
+    embed.add_field(name=_("Your Server"), value=yourserver)
+    embed.add_field(name=_("Your Members"), value=yourmembers)
+    embed.add_field(name=_('Uptime'), value=uptime_str)
+    embed.set_footer(text=_('For support, contact us on our Discord server. Invite Code: hhVjAN8'))
     try:
         await channel.send(embed=embed)
     except discord.HTTPException:
@@ -3354,18 +3354,16 @@ async def recover(ctx):
                                 status = None
                             if _('trainers') in message.content:
                                 messagesplit = message.content.split()
-                                if messagesplit[(- 2)].isdigit():
-                                    count = int(messagesplit[(- 2)])
-                                else:
-                                    count = 1
                                 if messagesplit[-1].isdigit():
                                     party = [int(messagesplit[-10]),int(messagesplit[-7]),int(messagesplit[-4]),int(messagesplit[-1])]
-                                    count = int(messagesplit[-10]) + int(messagesplit[-7]) + int(messagesplit[-4]) + int(messagesplit[-1])
+                                    count = party[0] + party[1] + party[2] + party[3] 
                                 else:
-                                    party = [0,0,0,count]
+                                    count = 1
+                                    party = [0,0,0,1]
                             else:
                                 count = 1
-                                for role in message.raw_mentions.roles:
+                                user = ctx.guild.get_member(trainerid)
+                                for role in user.roles:
                                     if role.name.lower() == 'mystic':
                                         party = [1,0,0,0]
                                         break
@@ -3380,7 +3378,7 @@ async def recover(ctx):
                             trainer_dict[trainerid] = {
                                 'status': status,
                                 'count': count,
-                                'party': party,
+                                'party': party
                             }
                         else:
                             continue
@@ -3399,8 +3397,7 @@ async def recover(ctx):
             'pokemon': pokemon,
             'egglevel': egglevel,
         }
-        for trainerid in guild_dict[channel.guild.id]['raidchannel_dict'][channel.id]['trainer_dict']:
-            await _edit_party(channel, Meowth.get_user_info(trainerid))
+        await _edit_party(channel, message.author)
         recovermsg = _("Meowth! This channel has been recovered! However, there may be some inaccuracies in what I remembered! Here's what I have:")
         bulletpoint = parse_emoji(ctx.guild, ':small_blue_diamond:')
         recovermsg += ('\n' + bulletpoint) + (await _interest(ctx))
@@ -3748,7 +3745,7 @@ async def coming(ctx, *, teamcounts: str=None):
 
     if teamcounts and teamcounts.split()[0].isdigit():
         total = int(teamcounts.split()[0])
-    elif ctx.author.id in trainer_dict:
+    elif (ctx.author.id in trainer_dict) and (trainer_dict[ctx.author.id]['status'] != None):
         total = trainer_dict[ctx.author.id]['count']
     elif teamcounts:
         total = sum([int(s) for s in teamcounts if s.isdigit()])
@@ -3850,7 +3847,7 @@ async def here(ctx, *, teamcounts: str=None):
             teamcounts = '1'
     if teamcounts and teamcounts.split()[0].isdigit():
         total = int(teamcounts.split()[0])
-    elif ctx.author.id in trainer_dict:
+    elif (ctx.author.id in trainer_dict) and (trainer_dict[ctx.author.id]['status'] != None):
         total = trainer_dict[ctx.author.id]['count']
     elif teamcounts:
         total = sum([int(s) for s in teamcounts if s.isdigit()])
@@ -4094,7 +4091,7 @@ async def lobby(ctx, *, count: str=None):
         else:
             await ctx.channel.send(_("Meowth! I can't understand how many are in your group. Just say **!here** if you're by yourself, or **!coming 5** for example if there are 5 in your group."))
             return
-    elif ctx.author.id in trainer_dict:
+    elif (ctx.author.id in trainer_dict) and (trainer_dict[ctx.author.id]['status'] != None):
         count = trainer_dict[ctx.author.id]['count']
     else:
         count = 1

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -3356,7 +3356,7 @@ async def recover(ctx):
                                 messagesplit = message.content.split()
                                 if messagesplit[-1].isdigit():
                                     party = [int(messagesplit[-10]),int(messagesplit[-7]),int(messagesplit[-4]),int(messagesplit[-1])]
-                                    count = party[0] + party[1] + party[2] + party[3] 
+                                    count = sum(party)
                                 else:
                                     count = 1
                                     party = [0,0,0,1]

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -3566,6 +3566,7 @@ async def _counters(ctx, pkmn, user = None, weather = None):
         ctrs = data['randomMove']['defenders'][-6:]
         def clean(txt):
             return txt.replace('_', ' ').title()
+        title = _('{pkmn} | {weather}').format(pkmn=pkmn.title(),weather=weather_list[index].title())
         stats_msg = _("**CP:** {raid_cp}\n").format(raid_cp=raid_cp)
         stats_msg += _("**Weather:** {weather}\n").format(weather=clean(weather))
         stats_msg += _("**Attacker Level:** {atk_levels}").format(atk_levels=atk_levels)

--- a/meowth/errors.py
+++ b/meowth/errors.py
@@ -185,11 +185,10 @@ def custom_error_handling(bot, logger):
             guild = ctx.guild
             msg = _('Meowth! Please use **!{cmd_name}** in an Active Raid channel. Use **!list** in any ').format(cmd_name=ctx.command.name)
             city_channels = bot.guild_dict[guild.id]['city_channels']
-            egg_check = ""
             try:
                 egg_check = bot.guild_dict[guild.id]['raidchannel_dict'].get(ctx.channel.id, None).get('type',None)
             except:
-                pass
+                egg_check = ""
             if len(city_channels) > 10:
                 msg += _('Region report channel to see active raids.')
             else:

--- a/meowth/errors.py
+++ b/meowth/errors.py
@@ -185,7 +185,11 @@ def custom_error_handling(bot, logger):
             guild = ctx.guild
             msg = _('Meowth! Please use **!{cmd_name}** in an Active Raid channel. Use **!list** in any ').format(cmd_name=ctx.command.name)
             city_channels = bot.guild_dict[guild.id]['city_channels']
-            egg_check = bot.guild_dict[guild.id]['raidchannel_dict'].get(ctx.channel.id, None).get('type',None)
+            egg_check = ""
+            try:
+                egg_check = bot.guild_dict[guild.id]['raidchannel_dict'].get(ctx.channel.id, None).get('type',None)
+            except:
+                pass
             if len(city_channels) > 10:
                 msg += _('Region report channel to see active raids.')
             else:
@@ -194,7 +198,7 @@ def custom_error_handling(bot, logger):
                     channel = discord.utils.get(guild.channels, id=c)
                     msg += '\n' + channel.mention
             if egg_check == "egg":
-                msg += '\nThis is an egg channel. The channel needs to be activated with **!raid <pokemon>** before I accept commands!'
+                msg += _('\nThis is an egg channel. The channel needs to be activated with **!raid <pokemon>** before I accept commands!')
             await ctx.channel.send(msg)
             pass
         elif isinstance(error, CityRaidChannelCheckFail):


### PR DESCRIPTION
Includes updated template

Bugfixes

Errors:
- added try/except block. That portion of code is called when using
!recover. its usage implies that channel isn't recognized as a raid
channel, so get('type') fails.

Main:
- more strings wrapped in parenthesis for pygettext, some removed and
fixes to errors i introduced with in the last PR. Sorry about those.
- fixed !recover. It will now build parties and count party members.
It will also update the raid summary embed message (_edit_party is called
at the end of the process)
- weather in the embed title tweaked to use strings from weather_list
(translatable) instead of those from match_list (used in the url, must
remain english)
- when using !cancel before, it fixed count to 1. building parties
checks for the existance of message sender within trainer_dict if total
isn't specified. basically, every party message sent after having
!cancel once where total isn't specified (like !c 3m 2v), will send an
error telling that total team is 1 instead of 'unspecified', like it is
for the very first message. It is fixed in line 3648 by adding a check
for status != None, which happens only after using !cancel.