### PR TITLE
Updating Level 5 Raids

### DIFF
--- a/data/raid_info.json
+++ b/data/raid_info.json
@@ -76,9 +76,7 @@
             "egg": "legendary",
             "egg_img": "5.png",
             "pokemon": [
-                250,
-                380,
-                381
+                250
             ],
             "hatchtime": 60,
             "raidtime": 45


### PR DESCRIPTION
Removing Latias and Latios from Legendary Raid List