### PR TITLE
Allow group on hatch.

### DIFF
--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -906,7 +906,7 @@ class RaidCog(Cog):
             stamp = await converter.convert(ctx, group_time)
         if stamp > raid.end:
             raise InvalidTime
-        elif raid.hatch and stamp < raid.hatch:
+        elif raid.hatch and stamp < raid.hatch - 1:
             raise InvalidTime
         grp_id = next(snowflake.create())
         d = {


### PR DESCRIPTION
Suggested 1s leeway on the group command before throwing an invalid time error because a raid report does not store the given hatch time precisely:
```
# Program flow for !raid 5 here 18:00

stamp = await converter.convert(ctx, gym_split[-1]) # 18:00:00
dt = stamp - time.time()                            # 00:29:55 = 18:00:00 - 17:30:05
endtime = dt/60                                     # 00:29:55 /60
hatch = time.time() + 60*endtime                    # 18:00:00.1 = 17:30:05.1 + 00:29:55 * 60/60
                                                    # !group 18:00 throws an error
```