### PR TITLE
table creation fix.

### DIFF
--- a/meowth/core/data_manager/tables.py
+++ b/meowth/core/data_manager/tables.py
@@ -19,7 +19,7 @@ def core_table_sqls():
                               "CONSTRAINT restart_savedata_pk "
                               "PRIMARY KEY (restart_snowflake));"),
 
-        'prefixes'       : ("CREATE TABLE prefix ("
+        'prefixes'       : ("CREATE TABLE prefixes ("
                           "guild_id bigint NOT NULL, "
                           "prefix text NOT NULL, "
                           "CONSTRAINT prefixes_pkey "


### PR DESCRIPTION
Meowth breaks because the table 'prefixes' does not exist and he attempts to fix it by creating a table 'prefix', after which the required table still does not exist.