### PR TITLE
config emoji unicode

### DIFF
--- a/meowth/config_template.py
+++ b/meowth/config_template.py
@@ -24,8 +24,8 @@ db_details = {
 dbdocid = 'google_sheet_id_here'
 
 emoji = {
-    'maybe': '\u1f914',
-    'coming': '\u1f697',
+    'maybe': '\U0001f914',
+    'coming': '\U0001f697',
     'here': '<:here:350686955316445185>',
     'cancel': '❌'
 }

--- a/meowth/config_template.py
+++ b/meowth/config_template.py
@@ -25,7 +25,7 @@ dbdocid = 'google_sheet_id_here'
 
 emoji = {
     'maybe': '🙋',
-    'coming': '\U0001f697',
+    'coming': '🚗',
     'here': '<:here:350686955316445185>',
     'cancel': '❌'
 }


### PR DESCRIPTION
It is displaying '\u1f91'+'4' = 'ᾑ4' and '\u1f69'+'7' = 'Ὡ7' instead of the expected emojis.