### PR TITLE
[feature] raid channels sorted by end time.

### DIFF
--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -644,13 +644,15 @@ class RaidCog(Cog):
             raidcontent += f"Raid reported in {ctx.channel.mention}!"
             raid_channel_name = await new_raid.channel_name()
             raid_channel_topic = new_raid.channel_topic
+            raid_channel_position = int(new_raid.end)
             if len(report_channels) > 1:
                 raid_channel_overwrites = formatters.perms_or(report_channels)
             else:
                 raid_channel_overwrites = dict(ctx.channel.overwrites)
             try:
                 raid_channel = await ctx.guild.create_text_channel(raid_channel_name,
-                    category=category, overwrites=raid_channel_overwrites, topic=raid_channel_topic)
+                    category=category, overwrites=raid_channel_overwrites,
+                    position=raid_channel_position, topic=raid_channel_topic)
             except discord.Forbidden:
                 raise commands.BotMissingPermissions(['Manage Channels'])
             new_raid.channel_ids.append(str(raid_channel.id))

--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -643,8 +643,8 @@ class RaidCog(Cog):
                 raidcontent = ""
             raidcontent += f"Raid reported in {ctx.channel.mention}!"
             raid_channel_name = await new_raid.channel_name()
-            raid_channel_topic = new_raid.channel_topic
             raid_channel_position = int(new_raid.end)
+            raid_channel_topic = new_raid.channel_topic
             if len(report_channels) > 1:
                 raid_channel_overwrites = formatters.perms_or(report_channels)
             else:


### PR DESCRIPTION
This inserts a newly created channel in a category in an order sorted by end time instead of at the bottom of the category.

It appears to be working fine in my test server but as the feature is quite critical to Meowth I would propose putting it on the beta bot?