### PR TITLE
Make import more user friendly.

### DIFF
--- a/meowth/exts/map/map_cog.py
+++ b/meowth/exts/map/map_cog.py
@@ -725,7 +725,7 @@ class Mapper(Cog):
         bot = self.bot
         stops_table = bot.dbi.table('pokestops')
         insert = stops_table.insert()
-        reader = csv.DictReader(codecs.iterdecode(file.readlines(), 'utf-8'))
+        reader = csv.DictReader(codecs.iterdecode(file.readlines(), 'utf-8-sig'))
         rows = []
         for row in reader:
             valid_data = {}

--- a/meowth/exts/map/map_cog.py
+++ b/meowth/exts/map/map_cog.py
@@ -670,7 +670,7 @@ class Mapper(Cog):
         bot = self.bot
         gyms_table = bot.dbi.table('gyms')
         insert = gyms_table.insert()
-        reader = csv.DictReader(codecs.iterdecode(file.readlines(), 'utf-8'))
+        reader = csv.DictReader(codecs.iterdecode(file.readlines(), 'utf-8-sig'))
         rows = []
         for row in reader:
             valid_data = {}

--- a/meowth/exts/map/map_cog.py
+++ b/meowth/exts/map/map_cog.py
@@ -689,7 +689,8 @@ class Mapper(Cog):
                 lat = float(row.get('lat'))
                 lon = float(row.get('lon'))
             except:
-                continue
+                await ctx.send(f"Failed to parse coordinates for gym '{row['name']}'.")
+                return False
             l10 = S2_L10.from_coords(bot, (lat, lon))
             valid_data['lat'] = lat
             valid_data['lon'] = lon
@@ -747,7 +748,8 @@ class Mapper(Cog):
                 lat = float(row.get('lat'))
                 lon = float(row.get('lon'))
             except:
-                continue
+                await ctx.send(f"Failed to parse coordinates for stop '{row['name']}'.")
+                return False
             l10 = S2_L10.from_coords(bot, (lat, lon))
             valid_data['lat'] = lat
             valid_data['lon'] = lon


### PR DESCRIPTION
For decoding, an **optional** UTF-8 encoded BOM at the start of the data will be skipped.

This should solve the import breaking for files created with editors that insert a BOM, like notepad.