### PR TITLE
One line research

### DIFF
--- a/meowth/exts/pkmn/pkmn_cog.py
+++ b/meowth/exts/pkmn/pkmn_cog.py
@@ -840,7 +840,7 @@ class Pokemon():
                     form = await forms.get_value()
                     id_list = await forms_table.query('pokemonid').where(formid=form).get_values()
                 else:
-                    names = fuzzymatch.get_matches(name_list, arg)
+                    names = fuzzymatch.get_matches(name_list, arg, scorer='ratio')
                     if names:
                         names = [x[0] for x in names]
                         ref = pokedex.query('pokemonid').where(

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -403,6 +403,7 @@ class ItemReward:
         item = await Item.convert(ctx, item_name_arg)
         if not item:
             return None
+        await ctx.send(f'{item.id}/{amount}')
         return cls(ctx.bot, f'{item.id}/{amount}')
     
 

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -620,12 +620,12 @@ class ResearchCog(Cog):
                 reward = None
             if not reward:
                 reward = await ItemReward.convert(ctx, reply.content)
-            reward = reward.id
             try:
                 await reply.delete()
                 await msg.delete()
             except:
                 pass
+        reward = reward.id
         research_id = next(snowflake.create())
         research = Research(research_id, ctx.bot, ctx.guild.id, ctx.author.id, task, location, reward, tz, time.time())
         embed = await ResearchEmbed.from_research(research)

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -13,7 +13,7 @@ from pytz import timezone
 from datetime import datetime, timedelta
 from dateparser import parse
 from math import ceil
-from typing import Optional
+from typing import Optional, Union
 import re
 
 from discord.ext import commands
@@ -535,10 +535,12 @@ class ResearchCog(Cog):
     @command(aliases=['res'])
     @research_checks.research_enabled()
     @checks.location_set()
-    async def research(self, ctx, task: Optional[Task], *, location: Pokestop):
+    async def research(self, ctx, reward: Optional[Union[Pokemon, ItemReward]], task: Optional[Task], *, location: Pokestop):
         """Report a Field Research task.
         
         **Arguments**
+        *reward (optional):* Description of the reward for the research. Either
+            a Pokemon or an item.
         *task (optional):* Either the text of the research task itself or
             the research category (e.g. `raid`). If a conversion to a Task cannot
             be made, Meowth asks you to select a category, then to select the
@@ -568,7 +570,7 @@ class ResearchCog(Cog):
             except:
                 pass
             task = await Task.convert(ctx, cat)
-        if isinstance(task, Task):
+        if isinstance(task, Task) and not reward:
             possible_rewards = await task.possible_rewards()
             if len(possible_rewards) == 1:
                 reward = possible_rewards[0]
@@ -607,7 +609,7 @@ class ResearchCog(Cog):
                     await multi.delete()
                 except:
                     pass
-        else:
+        elif not reward:
             msg = await ctx.send('What is the reward for this Research? Please type your response below.')
             def check(m):
                 return m.author == ctx.author and m.channel == ctx.channel

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -639,6 +639,7 @@ class ResearchCog(Cog):
                 await msg.delete()
             except:
                 pass
+        await ctx.send(str(reward))
         reward = reward.id
         research_id = next(snowflake.create())
         research = Research(research_id, ctx.bot, ctx.guild.id, ctx.author.id, task, location, reward, tz, time.time())

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -402,7 +402,7 @@ class ItemReward:
         item_name_arg = " ".join(item_args)
         item = await Item.convert(ctx, item_name_arg)
         if not item:
-            return None
+            raise ValueError
         await ctx.send(f'{item.id}/{amount}')
         return cls(ctx.bot, f'{item.id}/{amount}')
     
@@ -631,16 +631,17 @@ class ResearchCog(Cog):
             except:
                 reward = None
             if not reward:
-                reward = await ItemReward.convert(ctx, reply.content)
-                if not reward:
+                try:
+                    reward = await ItemReward.convert(ctx, reply.content)
+                except:
                     reward = ItemReward(ctx.bot, f'partial/{reply.content}/1')
             try:
                 await reply.delete()
                 await msg.delete()
             except:
                 pass
-        await ctx.send(str(reward))
-        reward = reward.id
+        if not isinstance(reward, str):
+            reward = reward.id
         research_id = next(snowflake.create())
         research = Research(research_id, ctx.bot, ctx.guild.id, ctx.author.id, task, location, reward, tz, time.time())
         embed = await ResearchEmbed.from_research(research)

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -318,11 +318,16 @@ class Task:
             task = display_dict[str(payload.emoji)]
             if task == 'Other':
                 if arg in categories:
-                    await ctx.send('What is the Task for this Research? Please type your answer below.')
+                    otherask = await ctx.send('What is the Task for this Research? Please type your answer below.')
                     def check(m):
                         return m.author == ctx.author and m.channel == ctx.channel
                     reply = await ctx.bot.wait_for('message', check=check)
                     arg = reply.content
+                    try:
+                        await reply.delete()
+                        await otherask.delete()
+                    except:
+                        pass
                 return PartialTask(ctx.bot, arg)
             try:
                 await multi.delete()
@@ -334,6 +339,10 @@ class Task:
             payload = await formatters.ask(ctx.bot, [taskask], user_list=[ctx.author.id])
             if not payload or str(payload.emoji) == '❎':
                 raise ValueError
+            try:
+                await taskask.delete()
+            except:
+                pass
         else:
             return PartialTask(ctx.bot, arg)
         return cls(ctx.bot, task)
@@ -392,6 +401,8 @@ class ItemReward:
                 amount = arg
         item_name_arg = " ".join(item_args)
         item = await Item.convert(ctx, item_name_arg)
+        if not item:
+            return None
         return cls(ctx.bot, f'{item.id}/{amount}')
     
 
@@ -620,6 +631,8 @@ class ResearchCog(Cog):
                 reward = None
             if not reward:
                 reward = await ItemReward.convert(ctx, reply.content)
+                if not reward:
+                    reward = ItemReward(ctx.bot, f'partial/{reply.content}/1')
             try:
                 await reply.delete()
                 await msg.delete()

--- a/meowth/exts/want/want_cog.py
+++ b/meowth/exts/want/want_cog.py
@@ -42,7 +42,6 @@ class Item:
         else:
             item_matches = []
             name_matches = []
-        await ctx.send(str(item_matches))
         if len(item_matches) > 1:
             react_list = formatters.mc_emoji(len(item_matches))
             choice_dict = dict(zip(react_list, item_matches))

--- a/meowth/exts/want/want_cog.py
+++ b/meowth/exts/want/want_cog.py
@@ -42,6 +42,7 @@ class Item:
         else:
             item_matches = []
             name_matches = []
+        await ctx.send(str(item_matches))
         if len(item_matches) > 1:
             react_list = formatters.mc_emoji(len(item_matches))
             choice_dict = dict(zip(react_list, item_matches))

--- a/meowth/exts/want/want_cog.py
+++ b/meowth/exts/want/want_cog.py
@@ -56,7 +56,7 @@ class Item:
         elif len(item_matches) == 1:
             item = item_matches[0]
         else:
-            return PartialItem(ctx.bot, arg)
+            return None
         return cls(ctx.bot, item)
 
 class PartialItem:

--- a/meowth/utils/fuzzymatch.py
+++ b/meowth/utils/fuzzymatch.py
@@ -30,14 +30,20 @@ def get_match(word_list: list, word: str, score_cutoff: int = 80):
         return (None, None)
     return result
 
-def get_matches(word_list: list, word: str, score_cutoff: int = 90, limit: int = 10):
+def get_matches(word_list: list, word: str, scorer = 'WRatio', score_cutoff: int = 90, limit: int = 10):
     """Uses fuzzywuzzy to see if word is close to entries in word_list
 
     Returns a list of tuples with (MATCH, SCORE)
     """
 
+    scorer_dict = {
+        'WRatio': fuzz.WRatio,
+        'ratio': fuzz.ratio
+    }
+    scorer = scorer_dict[scorer]
+
     return process.extractBests(
-        word, word_list, processor=pre, scorer=fuzz.WRatio, score_cutoff=score_cutoff, limit=limit)
+        word, word_list, processor=pre, scorer=scorer, score_cutoff=score_cutoff, limit=limit)
 
 class FuzzyEnum(Enum):
     """Enumeration with fuzzy-matching classmethods."""


### PR DESCRIPTION
The major goal of this branch is to enable a research command without having to go through any reaction prompts from the bot at all. In addition, though, it includes some tweaks to the way Pokemon names are matched - namely, Pokemon names are matched using `fuzz.ratio` rather than `fuzz.WRatio` in an attempt to improve performance.