### PR TITLE
match both stops and gyms for POI

### DIFF
--- a/meowth/exts/map/map_cog.py
+++ b/meowth/exts/map/map_cog.py
@@ -518,7 +518,14 @@ class POI():
         if not loc_id:
             city = await report_channel.city()
             return PartialPOI(ctx.bot, city, arg)
-        return cls(ctx.bot, loc_id)
+        gym = ctx.bot.dbi.table('gyms').query()
+        gym = gym.where(id=loc_id)
+        gym = gym.where(guild=ctx.guild)
+        # Not guaranteed but there should be a good chance the intersection of gym and stop ids is empty for a guild.
+        if gym:
+            return Gym(ctx.bot, loc_id)
+        else:
+            return Pokestop(ctx.bot, loc_id)
 
 
 class Gym(POI):


### PR DESCRIPTION
Rewrote the POI converter to take as data the union of stop data and gym data, instead of only trying gyms when no stops were returned. (As a side note I also fixed the POI converter overwriting ctx.channel, which led to replies to commands being posted in the reporting channel instead of the channel where the command is used.) Then the Gym, Stop and POI converter all had duplicate code so I put that in a function. Hopefully that went alright...

Please test on the beta bot. I can't get my own database to work with known locations yet. So I only know it doesn't break for unknown locations.

