### PR TITLE
don't drop all wants

### DIFF
--- a/meowth/exts/want/want_cog.py
+++ b/meowth/exts/want/want_cog.py
@@ -186,7 +186,9 @@ class Want():
                         await role.delete()
                     except:
                         pass
-                await _data.delete()
+                _update = self._update
+                _update.values(role=None)
+                await _update.commit()
             return False
         
     async def role(self):


### PR DESCRIPTION
When Meowth deletes the role because it dropped below the threshold he does not simply delete the role value, he drops the entire row from the database.