### PR TITLE
allow meetup today

### DIFF
--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -1084,17 +1084,20 @@ class RaidCog(Cog):
             stamp = time.time() + 60*int(newtime)
         else:
             try:
-                newdt = parse(newtime, settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True})
+                newdt = parse(newtime,
+                              settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True, 'STRICT_PARSING': True})
                 if not newdt:
-                    return await ctx.error(f'Could not convert {newtime} to a datetime object')
-                if isinstance(raid_or_meetup, Raid):
-                    oldstamp = raid_or_meetup.end
-                elif isinstance(raid_or_meetup, Meetup):
-                    oldstamp = raid_or_meetup.start
-                olddt = raid_or_meetup.local_datetime(oldstamp)
-                nowdt = raid_or_meetup.local_datetime(time.time())
-                if newdt.date() == nowdt.date():
-                    newdt = newdt.combine(olddt.date(), newdt.timetz())
+                    newdt = parse(newtime, settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True})
+                    if not newdt:
+                        return await ctx.error(f'Could not convert {newtime} to a datetime object')
+                    if isinstance(raid_or_meetup, Raid):
+                        oldstamp = raid_or_meetup.end
+                    elif isinstance(raid_or_meetup, Meetup):
+                        oldstamp = raid_or_meetup.start
+                    olddt = raid_or_meetup.local_datetime(oldstamp)
+                    nowdt = raid_or_meetup.local_datetime(time.time())
+                    if newdt.date() == nowdt.date():
+                        newdt = newdt.combine(olddt.date(), newdt.timetz())
                 stamp = newdt.timestamp()
             except:
                 raise


### PR DESCRIPTION
I read through the documentation of dateparser. Strict parsing will only return a datetime object if the date is fully specified and None otherwise. If the strict parsing returns None (i.e. if the date is not fully specified) it will fall back to the old code that overwrites the day if it equals today.

Examples that work:
7 aug 2019 6pm
today 6pm

Examples that won't work:
7 aug 6pm
(Date is not fully specified.)