### PR TITLE
Timerset fix

### DIFF
--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -1095,7 +1095,7 @@ class RaidCog(Cog):
                     oldstamp = raid_or_meetup.start
                 olddt = raid_or_meetup.local_datetime(oldstamp)
                 nowdt = raid_or_meetup.local_datetime(time.time())
-                if newdt.date() == nowdt.date():
+                if newdt.date() == nowdt.date() and 'today' not in newtime:
                     newdt = newdt.combine(olddt.date(), newdt.timetz())
                 stamp = newdt.timestamp()
             except:

--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -1086,20 +1086,17 @@ class RaidCog(Cog):
             stamp = time.time() + 60*int(newtime)
         else:
             try:
-                newdt = parse(newtime,
-                              settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True, 'STRICT_PARSING': True})
+                newdt = parse(newtime, settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True})
                 if not newdt:
-                    newdt = parse(newtime, settings={'TIMEZONE': zone, 'RETURN_AS_TIMEZONE_AWARE': True})
-                    if not newdt:
-                        return await ctx.error(f'Could not convert {newtime} to a datetime object')
-                    if isinstance(raid_or_meetup, Raid):
-                        oldstamp = raid_or_meetup.end
-                    elif isinstance(raid_or_meetup, Meetup):
-                        oldstamp = raid_or_meetup.start
-                    olddt = raid_or_meetup.local_datetime(oldstamp)
-                    nowdt = raid_or_meetup.local_datetime(time.time())
-                    if newdt.date() == nowdt.date():
-                        newdt = newdt.combine(olddt.date(), newdt.timetz())
+                    return await ctx.error(f'Could not convert {newtime} to a datetime object')
+                if isinstance(raid_or_meetup, Raid):
+                    oldstamp = raid_or_meetup.end
+                elif isinstance(raid_or_meetup, Meetup):
+                    oldstamp = raid_or_meetup.start
+                olddt = raid_or_meetup.local_datetime(oldstamp)
+                nowdt = raid_or_meetup.local_datetime(time.time())
+                if newdt.date() == nowdt.date():
+                    newdt = newdt.combine(olddt.date(), newdt.timetz())
                 stamp = newdt.timestamp()
             except:
                 raise


### PR DESCRIPTION
The previous (#285) did not have the expected results as instead of returning None, the strict parsing sometimes interprets the given time as a date. So this is to revert that commit.

As an alternative I added a simple check if 'today' is explicitly given as argument. It's not ideal but at least there will be a way to force meowth to stop overwriting the date.