### PR TITLE
meetup embed fix

### DIFF
--- a/meowth/exts/raid/objects.py
+++ b/meowth/exts/raid/objects.py
@@ -3633,8 +3633,8 @@ class MeetupEmbed:
     def __init__(self, embed):
         self.embed = embed
     
-    status_index = 0
-    team_index = 1
+    status_index = 1
+    team_index = 2
 
     @property
     def status_str(self):


### PR DESCRIPTION
Location has become field 0, so status and team should overwrite 1&2 on an embed edit.