### PR TITLE
show groups in report channel

### DIFF
--- a/meowth/exts/raid/objects.py
+++ b/meowth/exts/raid/objects.py
@@ -3133,6 +3133,7 @@ class ReportEmbed():
         if raid.status == 'egg':
             boss_str = await raid.boss_list_str()
             fields['Boss Interest'] = boss_str
+        fields['Groups'] = raid.grps_str + "\u200b"
         color = raid.guild.me.color
         embed = formatters.make_embed(icon=RaidEmbed.raid_icon, title="Raid Report", msg_colour=color,
             thumbnail=img_url, fields=fields, footer=footer, footer_icon=footer_icon)


### PR DESCRIPTION
I think the group time should be included; it's one of the most vital info.