### PR TITLE
obo fix

### DIFF
--- a/meowth/exts/trade/trade_cog.py
+++ b/meowth/exts/trade/trade_cog.py
@@ -392,7 +392,11 @@ class TradeCog(Cog):
         def check(m):
             return m.channel == ctx.channel and m.author == ctx.author
         wantmsg = await ctx.bot.wait_for('message', check=check)
-        wantargs = shlex.split(wantmsg.content.lower())
+        if ',' in wantmsg.content:
+            wantargs = wantmsg.content.lower().split(',')
+            wantargs = list(map(str.strip, wantargs))
+        else:
+            wantargs = shlex.split(wantmsg.content.lower())
         if 'any' in wantargs:
             wantargs.remove('any')
             accept_any = True

--- a/meowth/exts/trade/trade_cog.py
+++ b/meowth/exts/trade/trade_cog.py
@@ -9,6 +9,7 @@ from meowth.utils import formatters, snowflake
 from discord.ext import commands
 
 import asyncio
+import shlex
 from functools import partial
 
 from . import trade_checks
@@ -387,12 +388,11 @@ class TradeCog(Cog):
             fields={"Invalid Pokemon": "\n".join(invalid_names)}
             await ctx.warning('The following Pokemon cannot be traded!',
                 fields=fields)
-        listmsg = await ctx.send(f"{ctx.author.display_name} - what Pokemon are you willing to accept in exchange? Use 'any' if you will accept anything and 'OBO' if you want to allow other offers. \n**NOTE: Use commas to separate Pokemon here. Do not wrap them in quotes.**")
+        listmsg = await ctx.send(f"{ctx.author.display_name} - what Pokemon are you willing to accept in exchange? Use 'any' if you will accept anything and 'OBO' if you want to allow other offers. \n**NOTE: Remember to wrap multi-word Pokemon arguments in quotes.**")
         def check(m):
             return m.channel == ctx.channel and m.author == ctx.author
         wantmsg = await ctx.bot.wait_for('message', check=check)
-        wantargs = wantmsg.content.lower().split(',')
-        wantargs = list(map(str.strip, wantargs))
+        wantargs = shlex.split(wantmsg.content.lower())
         if 'any' in wantargs:
             wantargs.remove('any')
             accept_any = True

--- a/meowth/exts/trade/trade_cog.py
+++ b/meowth/exts/trade/trade_cog.py
@@ -300,7 +300,7 @@ class Trade():
                 def check(m):
                     return m.channel == chn and m.author == trader
                 offermsg = await self.bot.wait_for('message', check=check)
-                offer = await Pokemon.from_arg(self.bot, chn, trader.id, offermsg.content)
+                offer = await Pokemon.from_arg(self.bot, 'trade', chn, trader.id, offermsg.content)
                 if not await offer._trade_available():
                     return await chn.send(f'{await offer.name()} cannot be traded!')
                 await askmsg.delete()


### PR DESCRIPTION
Meowth crashes when someone makes an 'obo' offer because the pokemon constructor is missing a required argument.