### PR TITLE
team fix

### DIFF
--- a/meowth/exts/users/users_cog.py
+++ b/meowth/exts/users/users_cog.py
@@ -390,7 +390,7 @@ class Team:
             query.where(team_name=match)
             team_id = await query.get_value()
         else:
-            return await ctx.send("Team not found!")
+            return
         
         return cls(ctx.bot, ctx.guild.id, team_id)
 
@@ -409,6 +409,8 @@ class Users(Cog):
     async def team(self, ctx, *, chosen_team: Team):
         """Set your Pokemon Go team."""
 
+        if not chosen_team:
+            return await ctx.send("Team not found!")
         meowthuser = MeowthUser(ctx.bot, ctx.author)
         data = await meowthuser._data.get()
         if len(data) == 0:

--- a/meowth/exts/users/users_cog.py
+++ b/meowth/exts/users/users_cog.py
@@ -409,7 +409,7 @@ class Users(Cog):
     async def team(self, ctx, *, chosen_team: Team):
         """Set your Pokemon Go team."""
 
-        if not chosen_team:
+        if chosen_team is None:
             return await ctx.send("Team not found!")
         meowthuser = MeowthUser(ctx.bot, ctx.author)
         data = await meowthuser._data.get()


### PR DESCRIPTION
The team converter returned a message object if it failed to convert to a team.
The team function subsequently tried to put the message.id into the database as team.id.

The converter will now return None and the team function returns if team is None.

