### PR TITLE
rocket channels

### DIFF
--- a/meowth/exts/map/map_cog.py
+++ b/meowth/exts/map/map_cog.py
@@ -543,6 +543,8 @@ class POI():
             query.where(wild=True)
         elif cmd == 'research':
             query.where(research=True)
+        elif cmd == 'rocket':
+            query.where(rocket=True)
         channelid_list = await query.get_values()
         channel_list = [ReportChannel(self.bot, self.bot.get_channel(x)) for x in channelid_list if self.bot.get_channel(x)]
         gym_channels = [y for y in channel_list if await y.point_in_channel(coords)]

--- a/meowth/exts/rocket/rocket_cog.py
+++ b/meowth/exts/rocket/rocket_cog.py
@@ -10,6 +10,7 @@ from meowth.utils.converters import ChannelMessage
 import time
 from datetime import datetime, timedelta
 import asyncio
+import pytz
 from pytz import timezone
 from math import ceil
 from discord.ext import commands


### PR DESCRIPTION
Added where `rocket=true` clause to the query.

pytz.utc in line 153/154 in rocket_cog.py was an unresolved reference.