### PR TITLE
adjust partial matching

### DIFF
--- a/meowth/utils/fuzzymatch.py
+++ b/meowth/utils/fuzzymatch.py
@@ -40,10 +40,10 @@ def fp_ratio(s1, s2, force_ascii=True, full_process=True):
     partial_scale = .9
 
     base = fuzz.ratio(p1, p2)
-    len_ratio = float(max(len(p1), len(p2))) / min(len(p1), len(p2))
+    len_ratio = float(max(len(p1), len(p2))-1) / min(len(p1), len(p2))
 
     # if strings are similar length, don't use partials
-    if len_ratio < 1.5:
+    if len_ratio < 1.3:
         try_partial = False
 
     if try_partial:


### PR DESCRIPTION
-Be a little more restrictive before attempting partial matching with very short strings, e.g. a length 2 string will now only attempt partial matching with strings >=4 instead of >=3.
-Be a little less restrictive before attempting partial matching with large strings, e.g. a length 20 string will attempt partial matching with strings >= 27 instead of >= 30.