### PR TITLE
time parsing autocorrect

### DIFF
--- a/meowth/exts/raid/raid_cog.py
+++ b/meowth/exts/raid/raid_cog.py
@@ -441,6 +441,7 @@ class RaidCog(Cog):
         """
         gym_split = gym_and_time.split()
         zone = await ctx.tz()
+        gym_split[-1] = gym_split[-1].replace(';', ':').replace('.', ':')
         if ':' in gym_split[-1]:
             converter = time_converter()
             stamp = await converter.convert(ctx, gym_split[-1])


### PR DESCRIPTION
For all the people who write 4.20pm instead of 4:20pm. (Also 4;20pm typo.)