### PR TITLE
Correct prefixes table creation statement

### DIFF
--- a/meowth/core/data_manager/tables.py
+++ b/meowth/core/data_manager/tables.py
@@ -19,7 +19,7 @@ def core_table_sqls():
                               "CONSTRAINT restart_savedata_pk "
                               "PRIMARY KEY (restart_snowflake));"),
 
-        'prefixes'       : ("CREATE TABLE prefix ("
+        'prefixes'       : ("CREATE TABLE prefixes ("
                           "guild_id bigint NOT NULL, "
                           "prefix text NOT NULL, "
                           "CONSTRAINT prefixes_pkey "


### PR DESCRIPTION
Current statement created an incorrectly named table (perhaps an oversight from an earlier migration?)