### PR TITLE
Fix issues with prefixes and config sql tables

### DIFF
--- a/meowth/core/bot.py
+++ b/meowth/core/bot.py
@@ -268,11 +268,12 @@ class Bot(commands.AutoShardedBot):
 
     # events
     async def on_guild_join(self, guild):
-        table = self.dbi.table('guild_settings')
+        table = self.dbi.table('guild_config')
         insert = table.insert
         d = {
             'guild_id': guild.id,
-            'version': self.version
+            'version': self.version,
+            'config_name': 'bot_version'
         }
         insert.row(**d)
         await insert.commit(do_update=True)

--- a/meowth/core/context.py
+++ b/meowth/core/context.py
@@ -296,7 +296,7 @@ class Context(commands.Context):
     async def version(self):
         if not self.guild:
             return None
-        table = self.bot.dbi.table('guild_settings')
+        table = self.bot.dbi.table('guild_config')
         query = table.query('version')
         try:
             query.where(guild_id=self.guild.id)

--- a/meowth/core/data_manager/tables.py
+++ b/meowth/core/data_manager/tables.py
@@ -6,7 +6,8 @@ def core_table_sqls():
         'guild_config' : ("CREATE TABLE guild_config ("
                           "guild_id bigint NOT NULL, "
                           "config_name text NOT NULL, "
-                          "config_value text NOT NULL, "
+                          "config_value text, "
+                          "version text NOT NULL, "
                           "CONSTRAINT guild_config_pkey "
                           "PRIMARY KEY (guild_id, config_name));"),
 

--- a/meowth/core/data_manager/tables.py
+++ b/meowth/core/data_manager/tables.py
@@ -7,7 +7,7 @@ def core_table_sqls():
                           "guild_id bigint NOT NULL, "
                           "config_name text NOT NULL, "
                           "config_value text NOT NULL, "
-                          "CONSTRAINT guild_config_pk "
+                          "CONSTRAINT guild_config_pkey "
                           "PRIMARY KEY (guild_id, config_name));"),
 
         'restart_savedata' : ("CREATE TABLE restart_savedata ("
@@ -19,7 +19,7 @@ def core_table_sqls():
                               "CONSTRAINT restart_savedata_pk "
                               "PRIMARY KEY (restart_snowflake));"),
 
-        'prefixes'       : ("CREATE TABLE prefix ("
+        'prefixes'       : ("CREATE TABLE prefixes ("
                           "guild_id bigint NOT NULL, "
                           "prefix text NOT NULL, "
                           "CONSTRAINT prefixes_pkey "

--- a/meowth/exts/admin/admin_cog.py
+++ b/meowth/exts/admin/admin_cog.py
@@ -294,9 +294,9 @@ class AdminCog(Cog):
         before enabling these.
         """
         guild_id = ctx.guild.id
-        settings = ctx.bot.dbi.table('guild_settings')
+        settings = ctx.bot.dbi.table('guild_config')
         insert = settings.insert
-        insert.row(guild_id=guild_id, version=ctx.bot.version)
+        insert.row(guild_id=guild_id, version=ctx.bot.version, config_name='enabled_raids')
         await insert.commit(do_update=True)
         try:
             await ctx.guild.me.edit(nick='Meowth 3.0')
@@ -668,7 +668,7 @@ class AdminCog(Cog):
 
         Usable only by server admins."""
         guild_id = ctx.guild.id
-        settings = ctx.bot.dbi.table('guild_settings')
+        settings = ctx.bot.dbi.table('guild_config')
         insert = settings.insert
         insert.row(guild_id=guild_id, version=ctx.bot.version)
         await insert.commit(do_update=True)
@@ -939,7 +939,7 @@ class AdminCog(Cog):
     async def configure(self, ctx):
         """Gives information about how to configure Meowth 3.0."""
         guild_id = ctx.guild.id
-        settings = ctx.bot.dbi.table('guild_settings')
+        settings = ctx.bot.dbi.table('guild_config')
         insert = settings.insert
         insert.row(guild_id=guild_id, version=ctx.bot.version)
         await insert.commit(do_update=True)


### PR DESCRIPTION
- Fix name of prefixes table
- Correct constraint terminology  in guild_config to match rest of code
- Change search for "guild_settings" on guild join to "guild_config"
- Add required primary key field of 'config_name' in table insert for guild join