### PR TITLE
use default party

### DIFF
--- a/meowth/exts/users/users_cog.py
+++ b/meowth/exts/users/users_cog.py
@@ -191,6 +191,8 @@ class MeowthUser:
                 if sum((mystic, instinct, valor, unknown)) > total:
                     total = sum((mystic, instinct, valor, unknown))
                 unknown = total - sum((mystic, instinct, valor))
+        if sum((mystic, instinct, valor, unknown)) == 0:
+            return await self.party()
         return [mystic, instinct, valor, unknown]
 
 


### PR DESCRIPTION
If someone types some random message after their rsvp, e.g.: "!c Im driving over now", Meowth will interpret that as their party.
And since it does not match any teams, Meowth will register the user as coming [0,0,0,0].

Instead Meowth should return the user's default party.