### PR TITLE
[WIP] Intents

### DIFF
--- a/meowth/core/bot.py
+++ b/meowth/core/bot.py
@@ -75,12 +75,16 @@ class Bot(commands.AutoShardedBot):
         self.preload_ext = config.preload_extensions
         self.dbi = DatabaseInterface(**config.db_details)
         self.data = DataManager(self.dbi)
-#        intents = discord.Intents.default()
-#        intents.members = True
+        intents = discord.Intents.none()
+        intents.guilds = True
+        intents.members = True
+        intents.messages = True
+        intents.reactions = True
         kwargs = dict(owner_id=self.owner,
                       command_prefix=self.dbi.prefix_manager,
                       status=discord.Status.dnd, case_insensitive=True,
-#                      intents=intents, 
+                      intents=intents,
+                      chunk_guilds_at_startup=False,
                       **kwargs)
         super().__init__(**kwargs)
         self.session = aiohttp.ClientSession(loop=self.loop)

--- a/meowth/core/context.py
+++ b/meowth/core/context.py
@@ -520,7 +520,8 @@ class GetTools:
         if isinstance(search_term, int):
             member = guild.get_member(search_term)
             if not member:
-                member = guild.fetch_member(search_term)
+                # TODO
+                pass
             return member
         if isinstance(search_term, str):
             member = self.get(guild.members, name=search_term)

--- a/meowth/core/context.py
+++ b/meowth/core/context.py
@@ -518,7 +518,10 @@ class GetTools:
         if not guild:
             return None
         if isinstance(search_term, int):
-            return guild.get_member(search_term)
+            member = guild.get_member(search_term)
+            if not member:
+                member = guild.fetch_member(search_term)
+            return member
         if isinstance(search_term, str):
             member = self.get(guild.members, name=search_term)
             if not member:

--- a/meowth/exts/admin/admin_cog.py
+++ b/meowth/exts/admin/admin_cog.py
@@ -32,7 +32,8 @@ def do_template(message, author, guild):
             if match.isdigit() and (not member):
                 member = guild.get_member(int(match))
                 if not member:
-                    member = guild.fetch_member(int(match))
+                    # TODO
+                    pass
             if not member:
                 not_found.append(full_match)
             return member.mention if member else full_match
@@ -564,7 +565,7 @@ class AdminCog(Cog):
             g = ctx.bot.get_guild(344960572649111552)
             gm = g.get_member(ctx.author.id)
             if not gm:
-                gm = g.fetch_member(ctx.author.id)
+                gm = await g.fetch_member(ctx.author.id)
             r = g.get_role(616734835104546826)
             if r not in gm.roles:
                 content = 'Unfortunately, because of the cost of using the AccuWeather API, you must be a Meowth Patreon Super Nerd to enable in-game weather forecasts. Visit www.patreon.com/meowthbot to become a Patron!'

--- a/meowth/exts/admin/admin_cog.py
+++ b/meowth/exts/admin/admin_cog.py
@@ -8,6 +8,7 @@ import re
 import pickle
 from typing import Union
 
+
 def do_template(message, author, guild):
     not_found = []
 
@@ -30,21 +31,23 @@ def do_template(message, author, guild):
             member = guild.get_member_named(match)
             if match.isdigit() and (not member):
                 member = guild.get_member(int(match))
-            if (not member):
+                if not member:
+                    member = guild.fetch_member(int(match))
+            if not member:
                 not_found.append(full_match)
             return member.mention if member else full_match
         elif match_type == '#':
             channel = discord.utils.get(guild.text_channels, name=match)
             if match.isdigit() and (not channel):
                 channel = guild.get_channel(int(match))
-            if (not channel):
+            if not channel:
                 not_found.append(full_match)
             return channel.mention if channel else full_match
         elif match_type == '&':
             role = discord.utils.get(guild.roles, name=match)
             if match.isdigit() and (not role):
                 role = discord.utils.get(guild.roles, id=int(match))
-            if (not role):
+            if not role:
                 not_found.append(full_match)
             return role.mention if role else full_match
     template_pattern = '(?i){(@|#|&|<)([^{}]+)}|{(user|server)}|<*:([a-zA-Z0-9]+):[0-9]*>*'
@@ -560,8 +563,10 @@ class AdminCog(Cog):
         if 'forecast' in enabled_commands:
             g = ctx.bot.get_guild(344960572649111552)
             gm = g.get_member(ctx.author.id)
+            if not gm:
+                gm = g.fetch_member(ctx.author.id)
             r = g.get_role(616734835104546826)
-            if not r in gm.roles:
+            if r not in gm.roles:
                 content = 'Unfortunately, because of the cost of using the AccuWeather API, you must be a Meowth Patreon Super Nerd to enable in-game weather forecasts. Visit www.patreon.com/meowthbot to become a Patron!'
                 await ctx.send(content)
             else:

--- a/meowth/exts/raid/objects.py
+++ b/meowth/exts/raid/objects.py
@@ -167,7 +167,7 @@ class Meetup:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             if tags:
                 name = member.mention
             else:
@@ -220,7 +220,7 @@ class Meetup:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -668,7 +668,8 @@ class Raid:
     def reporter(self):
         reporter = self.guild.get_member(self.reporter_id)
         if not reporter:
-            reporter = self.guild.fetch_member(self.reporter_id)
+            # TODO
+            pass
         return reporter
 
     @property
@@ -1323,10 +1324,10 @@ class Raid:
     async def raid_invite(self, inviter_id, invitee_id):
         inviter = self.guild.get_member(inviter_id)
         if not inviter:
-            inviter = self.guild.fetch_member(inviter_id)
+            inviter = await self.guild.fetch_member(inviter_id)
         invitee = self.guild.get_member(invitee_id)
         if not invitee:
-            invitee = self.guild.fetch_member(invitee_id)
+            invitee = await self.guild.fetch_member(invitee_id)
         inviter_name = inviter.display_name
         invitee_name = invitee.display_name
         meowthinvitee = MeowthUser.from_id(self.bot, invitee_id)
@@ -1369,7 +1370,7 @@ class Raid:
         for x in invites:
             member = self.guild.get_member(x)
             if not member:
-                member = self.guild.fetch_member(x)
+                member = await self.guild.fetch_member(x)
             meowthuser = MeowthUser.from_id(self.bot, x)
             ign = await meowthuser.ign()
             if ign:
@@ -2422,7 +2423,7 @@ class Raid:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             if tags:
                 name = member.mention
             else:
@@ -2505,7 +2506,7 @@ class Raid:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -2553,7 +2554,7 @@ class Raid:
             for user in users:
                 member = self.guild.get_member(user)
                 if not member:
-                    member = self.guild.fetch_member(user)
+                    member = await self.guild.fetch_member(user)
                 if not member:
                     continue
                 if tags:
@@ -2581,7 +2582,7 @@ class Raid:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -2996,7 +2997,7 @@ class Train:
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
             if not member:
-                member = self.guild.fetch_member(trainer)
+                member = await self.guild.fetch_member(trainer)
             name = member.display_name
             party = trainer_dict[trainer]['party']
             total = sum(party)
@@ -3522,7 +3523,7 @@ class RaidEmbed():
             fields['Groups'] = grps_str
         reporter = raid.guild.get_member(raid.reporter_id)
         if not reporter:
-            reporter = raid.guild.fetch_member(raid.reporter_id)
+            reporter = await raid.guild.fetch_member(raid.reporter_id)
         if reporter:
             reporter = reporter.display_name
         footer = f"Reported by {reporter} • {raid.time_str} (not updated)"
@@ -3711,7 +3712,7 @@ class EggEmbed():
         fields['Groups'] = (False, grps_str)
         reporter = raid.guild.get_member(raid.reporter_id)
         if not reporter:
-            reporter = raid.guild.fetch_member(raid.reporter_id)
+            reporter = await raid.guild.fetch_member(raid.reporter_id)
         if reporter:
             reporter = reporter.display_name
         footer_text = f"Reported by {reporter} • {raid.time_str} (not updated)"

--- a/meowth/exts/raid/objects.py
+++ b/meowth/exts/raid/objects.py
@@ -166,6 +166,8 @@ class Meetup:
         lobby_count = 0
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             if tags:
                 name = member.mention
             else:
@@ -217,6 +219,8 @@ class Meetup:
         other_list = []
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -294,8 +298,6 @@ class Meetup:
             chn = self.channel
             if chn:
                 rsvpembed = RSVPEmbed.from_meetup(self).embed
-                guild = self.guild
-                member = guild.get_member(user_id)
                 if status == 'maybe':
                     display_status = 'is interested'
                 elif status == 'coming':
@@ -306,9 +308,9 @@ class Meetup:
                     display_status = 'has canceled'
                 else:
                     return
-                content = f"{member.display_name} {display_status}!"
+                content = f"<@!{user_id}> {display_status}!"
                 try:
-                    await chn.send(content)
+                    await chn.send(content, allowed_mentions=discord.AllowedMentions.none())
                     await chn.send(embed=rsvpembed, delete_after=15)
                 except:
                     return
@@ -664,8 +666,11 @@ class Raid:
 
     @property
     def reporter(self):
-        return self.guild.get_member(self.reporter_id)
-    
+        reporter = self.guild.get_member(self.reporter_id)
+        if not reporter:
+            reporter = self.guild.fetch_member(self.reporter_id)
+        return reporter
+
     @property
     def report_channel(self):
         return self.bot.get_channel(self.report_channel_id)
@@ -763,10 +768,9 @@ class Raid:
     
     async def raidgroup_ask(self, channel, user):
         color = self.guild.me.color
-        member = self.guild.get_member(user)
         grps_str = self.grps_str
         embed = formatters.make_embed(title='Groups (Boss Damage Estimate)', content=grps_str, msg_colour=color)
-        msg = await channel.send(f"{member.mention}: select a group from the list below!, or use \u2754 to remain ungrouped!", embed=embed)
+        msg = await channel.send(f"<@!{user}>: select a group from the list below!, or use \u2754 to remain ungrouped!", embed=embed)
         groups = self.group_list
         emoji_list = [x['emoji'] for x in groups]
         emoji_list += '\u2754'
@@ -1300,8 +1304,6 @@ class Raid:
 
     async def invite_ask(self, user_id):
         meowthuser = MeowthUser.from_id(self.bot, user_id)
-        invitee = self.guild.get_member(user_id)
-        invitee_name = invitee.display_name
         data = (await meowthuser._data.get())[0]
         friendcode = data.get('friendcode')
         users_can_invite = self.users_can_invite
@@ -1310,16 +1312,21 @@ class Raid:
                 chn = self.bot.get_channel(int(chnid))
         if chn:
             if not users_can_invite:
-                return await chn.send(f"{invitee_name}, there isn't anyone at the raid who can invite you yet! You may need to check back later as others RSVP.")
-            content = f"If you are going to do the raid and plan to invite {invitee_name}, hit the ✉ below!"
-            msg = await chn.send(content)
+                content = f"<@!{user_id}>, there isn't anyone at the raid who can invite you yet! You may need to check back later as others RSVP."
+                return await chn.send(content, allowed_mentions=discord.AllowedMentions.none())
+            content = f"If you are going to do the raid and plan to invite <@!{user_id}>, hit the ✉ below!"
+            msg = await chn.send(content, allowed_mentions=discord.AllowedMentions.none())
             payload = await formatters.ask(self.bot, [msg], user_list=users_can_invite, react_list=['✉'])
             if payload:
                 return await self.raid_invite(payload.user_id, user_id)
     
     async def raid_invite(self, inviter_id, invitee_id):
         inviter = self.guild.get_member(inviter_id)
+        if not inviter:
+            inviter = self.guild.fetch_member(inviter_id)
         invitee = self.guild.get_member(invitee_id)
+        if not invitee:
+            invitee = self.guild.fetch_member(invitee_id)
         inviter_name = inviter.display_name
         invitee_name = invitee.display_name
         meowthinvitee = MeowthUser.from_id(self.bot, invitee_id)
@@ -1361,6 +1368,8 @@ class Raid:
         content = "Your group is starting the raid! You have agreed to invite the following users:"
         for x in invites:
             member = self.guild.get_member(x)
+            if not member:
+                member = self.guild.fetch_member(x)
             meowthuser = MeowthUser.from_id(self.bot, x)
             ign = await meowthuser.ign()
             if ign:
@@ -1436,7 +1445,6 @@ class Raid:
                         continue
                     rsvpembed = RSVPEmbed.from_raid(self).embed
                     guild = self.bot.get_guild(self.guild_id)
-                    member = guild.get_member(user_id)
                     if status == 'maybe':
                         display_status = 'is interested'
                     elif status == 'coming':
@@ -1451,12 +1459,11 @@ class Raid:
                         display_status = 'has canceled'
                     else:
                         break
-                    content = f"{member.display_name} {display_status}!"
+                    content = f"<@!{user_id}> {display_status}!"
                     if self.user_was_invited(user_id):
                         inviter_id = self.user_who_invited(user_id)
-                        inviter = self.guild.get_member(inviter_id)
-                        content = f"{inviter.display_name} is inviting {member.display_name} to the raid!" 
-                    await chn.send(content)
+                        content = f"<@!{inviter_id}> is inviting <@!{user_id}> to the raid!"
+                    await chn.send(content, allowed_mentioned=discord.AllowedMentions.none())
                     await chn.send(embed=rsvpembed, delete_after=15)
                     if status == 'invite':
                         self.bot.loop.create_task(self.invite_ask(user_id))
@@ -1464,14 +1471,14 @@ class Raid:
                         if self.users_need_invite:
                             num_invites = len(self.users_need_invite)
                             if num_invites == 1:
-                                content = f"{member.display_name}, one trainer needs an invite to the raid! Use `!list invites` to see who needs an invite."
+                                content = f"<@!{user_id}>, one trainer needs an invite to the raid! Use `!list invites` to see who needs an invite."
                             else:
-                                content = f"{member.display_name}, {num_invites} trainers need an invite to the raid! Use `!list invites` to see who needs an invite."
-                            self.bot.loop.create_task(chn.send(content))
+                                content = f"<@!{user_id}>, {num_invites} trainers need an invite to the raid! Use `!list invites` to see who needs an invite."
+                            self.bot.loop.create_task(chn.send(content, allowed_mentions=discord.AllowedMentions.none()))
                     if self.group_list:
-                        grp = self.user_grp(member.id)
-                        if not grp and status in ('coming', 'here', 'remote') and not self.user_was_invited(member.id):
-                            return await self.raidgroup_ask(chn, member.id)
+                        grp = self.user_grp(user_id)
+                        if not grp and status in ('coming', 'here', 'remote') and not self.user_was_invited(user_id):
+                            return await self.raidgroup_ask(chn, user_id)
         elif user_id and group and not self.user_was_invited(user_id):
             if self.channel_ids:
                 for chnid in self.channel_ids:
@@ -1479,13 +1486,10 @@ class Raid:
                     if not chn:
                         continue
                     rsvpembed = RSVPEmbed.from_raidgroup(self, group).embed
-                    guild = self.bot.get_guild(self.guild_id)
-                    member = guild.get_member(user_id)
-                    content = f"{member.display_name} has joined Group {group['emoji']}!"
-                    await chn.send(content)
+                    content = f"<@!{user_id}> has joined Group {group['emoji']}!"
+                    await chn.send(content, allowed_mentions=discord.AllowedMentions.none())
                     await chn.send(embed=rsvpembed, delete_after=15)
-        
-    
+
     async def monitor_status(self):
         try:
             hatch = self.hatch
@@ -2075,8 +2079,7 @@ class Raid:
                 cancel_list.append(meowthuser)
         mention_list = []
         for user_id in int_list:
-            member = self.guild.get_member(user_id)
-            mention = member.mention
+            mention = f"<@!{user_id}>"
             mention_list.append(mention)
         self.pkmn = RaidBoss(Pokemon(self.bot, pkmn))
         family_id = await self.pkmn._familyId()
@@ -2195,12 +2198,11 @@ class Raid:
         else:
             sync = False
         await channel.edit(name=new_name, category=category, sync_permissions=sync)
-        member = guild.get_member(user_id)
-        content = f"Channel archive initiated by {member.display_name}."
+        content = f"Channel archive initiated by <@!{user_id}>."
         if reason:
             content += f" Reason: {reason}"
         content += "\nDeleted messages from this channel will be posted below."
-        await channel.send(content)
+        await channel.send(content, allowed_mentions=discord.AllowedMentions.none())
         try:
             table = self.bot.dbi.table('discord_messages')
             query = table.query
@@ -2419,6 +2421,8 @@ class Raid:
         lobby_count = 0
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             if tags:
                 name = member.mention
             else:
@@ -2477,7 +2481,7 @@ class Raid:
         while self.status != 'expired':
             invites = self.users_need_invite
             emoji = formatters.mc_emoji(len(invites))
-            invite_names = [self.guild.get_member(x).display_name for x in invites]
+            invite_names = [f"<@!{user_id}>" for user_id in invites]  # This will be used in an embed so not mentioned.
             display_dict = dict(zip(emoji, invite_names))
             choice_dict = dict(zip(emoji, invites))
             embed = formatters.mc_embed(display_dict)
@@ -2500,6 +2504,8 @@ class Raid:
         other_list = []
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -2547,6 +2553,8 @@ class Raid:
             for user in users:
                 member = self.guild.get_member(user)
                 if not member:
+                    member = self.guild.fetch_member(user)
+                if not member:
                     continue
                 if tags:
                     name = member.mention
@@ -2572,6 +2580,8 @@ class Raid:
         boss_dict = {x: [] for x in boss_list}
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             if not member:
                 continue
             if tags:
@@ -2985,6 +2995,8 @@ class Train:
         other_list = []
         for trainer in trainer_dict:
             member = self.guild.get_member(trainer)
+            if not member:
+                member = self.guild.fetch_member(trainer)
             name = member.display_name
             party = trainer_dict[trainer]['party']
             total = sum(party)
@@ -3179,14 +3191,13 @@ class Train:
             await msg.edit(embed=train_embed.embed)
         channel = self.channel
         guild = channel.guild
-        member = guild.get_member(user_id)
         if status == 'join':
             status_str = ' has joined the train!'
         elif status == 'cancel':
             status_str =' has left the train!'
-        content = f'{member.display_name}{status_str}'
+        content = f'<@!{user_id}>{status_str}'
         embed = TRSVPEmbed.from_train(self).embed
-        await channel.send(content)
+        await channel.send(content, allowed_mentions=discord.AllowedMentions.none())
         await channel.send(embed=embed, delete_after=15)
         if not self.trainer_dict:
             await self.end_train()
@@ -3242,12 +3253,11 @@ class Train:
         new_name = 'archived-' + old_name
         category = await archive_category(bot, guild)
         await channel.edit(name=new_name, category=category, sync_permissions=True)
-        member = guild.get_member(user_id)
-        content = f"Channel archive initiated by {member.display_name}."
+        content = f"Channel archive initiated by <@!{user_id}>."
         if reason:
             content += f" Reason: {reason}"
         content += "\nDeleted messages from this channel will be posted below."
-        await channel.send(content)
+        await channel.send(content, allowed_mentions=discord.AllowedMentions.none())
         table = self.bot.dbi.table('discord_messages')
         query = table.query
         query.where(channel_id=channel.id)
@@ -3511,6 +3521,8 @@ class RaidEmbed():
         else:
             fields['Groups'] = grps_str
         reporter = raid.guild.get_member(raid.reporter_id)
+        if not reporter:
+            reporter = raid.guild.fetch_member(raid.reporter_id)
         if reporter:
             reporter = reporter.display_name
         footer = f"Reported by {reporter} • {raid.time_str} (not updated)"
@@ -3698,6 +3710,8 @@ class EggEmbed():
         grps_str = raid.grps_str + "\u200b"
         fields['Groups'] = (False, grps_str)
         reporter = raid.guild.get_member(raid.reporter_id)
+        if not reporter:
+            reporter = raid.guild.fetch_member(raid.reporter_id)
         if reporter:
             reporter = reporter.display_name
         footer_text = f"Reported by {reporter} • {raid.time_str} (not updated)"

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -842,6 +842,8 @@ class ResearchEmbed:
             'Reward': desc + "\n<:silph:548259248442703895>Research tasks and rewards provided by [The Silph Road](https://thesilphroad.com/research-tasks)"
         }
         reporter = research.guild.get_member(research.reporter_id)
+        if not reporter:
+            reporter = research.guild.fetch_member(research.reporter_id)
         color = research.guild.me.color
         reporter_name = reporter.display_name
         reporter_avy = reporter.avatar_url

--- a/meowth/exts/research/research_cog.py
+++ b/meowth/exts/research/research_cog.py
@@ -843,7 +843,7 @@ class ResearchEmbed:
         }
         reporter = research.guild.get_member(research.reporter_id)
         if not reporter:
-            reporter = research.guild.fetch_member(research.reporter_id)
+            reporter = await research.guild.fetch_member(research.reporter_id)
         color = research.guild.me.color
         reporter_name = reporter.display_name
         reporter_avy = reporter.avatar_url

--- a/meowth/exts/rocket/rocket_cog.py
+++ b/meowth/exts/rocket/rocket_cog.py
@@ -469,7 +469,10 @@ class RocketEmbed():
             fields['Pokemon'] = "\n".join(pkmn_names)
         fields['Location'] = f'[{directions_text}]({directions_url})'
         img_url = mod.img_url()
-        reporter = mod.guild.get_member(mod.reporter_id).display_name
+        reporter = mod.guild.get_member(mod.reporter_id)
+        if not reporter:
+            reporter = mod.guild.fetch_member(mod.reporter_id)
+        reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(mod.created)
         color = mod.guild.me.color

--- a/meowth/exts/rocket/rocket_cog.py
+++ b/meowth/exts/rocket/rocket_cog.py
@@ -471,7 +471,7 @@ class RocketEmbed():
         img_url = mod.img_url()
         reporter = mod.guild.get_member(mod.reporter_id)
         if not reporter:
-            reporter = mod.guild.fetch_member(mod.reporter_id)
+            reporter = await mod.guild.fetch_member(mod.reporter_id)
         reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(mod.created)

--- a/meowth/exts/scoreboard/scoreboard_cog.py
+++ b/meowth/exts/scoreboard/scoreboard_cog.py
@@ -133,7 +133,7 @@ class ScoreCog(Cog):
             try:
                 member = ctx.guild.get_member(row['user_id'])
                 if not member:
-                    member = ctx.guild.fetch_member(row['user_id'])
+                    member = await ctx.guild.fetch_member(row['user_id'])
                 name = member.display_name
             except:
                 continue

--- a/meowth/exts/scoreboard/scoreboard_cog.py
+++ b/meowth/exts/scoreboard/scoreboard_cog.py
@@ -131,7 +131,10 @@ class ScoreCog(Cog):
         for i in range(len(data)):
             row = data[i]
             try:
-                name = ctx.guild.get_member(row['user_id']).display_name
+                member = ctx.guild.get_member(row['user_id'])
+                if not member:
+                    member = ctx.guild.fetch_member(row['user_id'])
+                name = member.display_name
             except:
                 continue
             names.append(name)

--- a/meowth/exts/trade/trade_cog.py
+++ b/meowth/exts/trade/trade_cog.py
@@ -82,15 +82,13 @@ class Trade():
             cls.by_offer[offer['msg']] = new_trade
         return new_trade
 
-
-
-
     @property
     def lister_name(self):
         g = self.bot.get_guild(self.guild_id)
         m = g.get_member(self.lister_id)
         if not m:
-            m = g.fetch_member(self.lister_id)
+            # TODO
+            pass
         return m.display_name
     
     @property
@@ -98,7 +96,8 @@ class Trade():
         g = self.bot.get_guild(self.guild_id)
         m = g.get_member(self.lister_id)
         if not m:
-            m = g.fetch_member(self.lister_id)
+            # TODO
+            pass
         return m
     
     @property
@@ -320,7 +319,7 @@ class Trade():
                         g = self.bot.get_guild(self.guild_id)
                         trader = g.get_member(offer['trader'])
                         if not trader:
-                            trader = g.fetch_member(offer['trader'])
+                            trader = await g.fetch_member(offer['trader'])
                         listed = offer['listed']
                         offered = offer['offered']
                         return await self.accept_offer(trader, listed, offered)
@@ -331,7 +330,7 @@ class Trade():
                         g = self.bot.get_guild(self.guild_id)
                         trader = g.get_member(offer['trader'])
                         if not trader:
-                            trader = g.fetch_member(offer['trader'])
+                            trader = await g.fetch_member(offer['trader'])
                         listed = offer['listed']
                         offered = offer['offered']
                         msg = offer['msg']

--- a/meowth/exts/trade/trade_cog.py
+++ b/meowth/exts/trade/trade_cog.py
@@ -89,12 +89,16 @@ class Trade():
     def lister_name(self):
         g = self.bot.get_guild(self.guild_id)
         m = g.get_member(self.lister_id)
+        if not m:
+            m = g.fetch_member(self.lister_id)
         return m.display_name
     
     @property
     def lister(self):
         g = self.bot.get_guild(self.guild_id)
         m = g.get_member(self.lister_id)
+        if not m:
+            m = g.fetch_member(self.lister_id)
         return m
     
     @property
@@ -315,6 +319,8 @@ class Trade():
                     if offer['msg'] == idstring:
                         g = self.bot.get_guild(self.guild_id)
                         trader = g.get_member(offer['trader'])
+                        if not trader:
+                            trader = g.fetch_member(offer['trader'])
                         listed = offer['listed']
                         offered = offer['offered']
                         return await self.accept_offer(trader, listed, offered)
@@ -324,6 +330,8 @@ class Trade():
                     if offer['msg'] == idstring:
                         g = self.bot.get_guild(self.guild_id)
                         trader = g.get_member(offer['trader'])
+                        if not trader:
+                            trader = g.fetch_member(offer['trader'])
                         listed = offer['listed']
                         offered = offer['offered']
                         msg = offer['msg']

--- a/meowth/exts/users/users_cog.py
+++ b/meowth/exts/users/users_cog.py
@@ -566,6 +566,8 @@ class Users(Cog):
         if match:
             meowthuser = await MeowthUser.from_ign(ctx.bot, match)
             member = ctx.guild.get_member(meowthuser.user.id)
+            if not member:
+                member = ctx.guild.fetch_member(meowthuser.user.id)
             if member:
                 name = member.display_name
             else:

--- a/meowth/exts/users/users_cog.py
+++ b/meowth/exts/users/users_cog.py
@@ -567,7 +567,7 @@ class Users(Cog):
             meowthuser = await MeowthUser.from_ign(ctx.bot, match)
             member = ctx.guild.get_member(meowthuser.user.id)
             if not member:
-                member = ctx.guild.fetch_member(meowthuser.user.id)
+                member = await ctx.guild.fetch_member(meowthuser.user.id)
             if member:
                 name = member.display_name
             else:

--- a/meowth/exts/want/want_cog.py
+++ b/meowth/exts/want/want_cog.py
@@ -209,7 +209,7 @@ class Want():
             if not role:
                 guild = self.guild
                 users = await self._users()
-                members = [guild.fetch_member(x) for x in users]  # Role creation isn't common, so API call is ok.
+                members = [await guild.fetch_member(x) for x in users]  # Role creation isn't common, so API call is ok.
                 members = [x for x in members if x]
                 raid_tiers = ['1', '2', '3', '4', '5', 'EX', 'MEGA']
                 if self.want.startswith('FAMILY'):

--- a/meowth/exts/wild/wild_cog.py
+++ b/meowth/exts/wild/wild_cog.py
@@ -871,7 +871,10 @@ class WildEmbed():
             'Moveset': moveset.strip(),
             'Gender': wild.pkmn.gender.title() if wild.pkmn.gender else "Unknown"
         }
-        reporter = wild.guild.get_member(wild.reporter_id).display_name
+        reporter = wild.guild.get_member(wild.reporter_id)
+        if not reporter:
+            reporter = wild.guild.fetch_member(wild.reporter_id)
+        reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(wild.created)
         color = wild.guild.me.color
@@ -903,7 +906,10 @@ class ModEmbed():
             fields['Pokemon'] = "\n".join(pkmn_names)
         fields['Location'] = f'[{directions_text}]({directions_url})'
         img_url = mod.img_url()
-        reporter = mod.guild.get_member(mod.reporter_id).display_name
+        reporter = mod.guild.get_member(mod.reporter_id)
+        if not reporter:
+            reporter = mod.guild.fetch_member(mod.reporter_id)
+        reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(mod.created)
         color = mod.guild.me.color

--- a/meowth/exts/wild/wild_cog.py
+++ b/meowth/exts/wild/wild_cog.py
@@ -873,7 +873,7 @@ class WildEmbed():
         }
         reporter = wild.guild.get_member(wild.reporter_id)
         if not reporter:
-            reporter = wild.guild.fetch_member(wild.reporter_id)
+            reporter = await wild.guild.fetch_member(wild.reporter_id)
         reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(wild.created)
@@ -908,7 +908,7 @@ class ModEmbed():
         img_url = mod.img_url()
         reporter = mod.guild.get_member(mod.reporter_id)
         if not reporter:
-            reporter = mod.guild.fetch_member(mod.reporter_id)
+            reporter = await mod.guild.fetch_member(mod.reporter_id)
         reporter = reporter.display_name
         footer = f"Reported by {reporter}"
         reportdt = datetime.fromtimestamp(mod.created)

--- a/meowth/utils/formatters.py
+++ b/meowth/utils/formatters.py
@@ -246,6 +246,8 @@ def deleted_message_embed(bot, data):
     guild = bot.get_guild(guild_id)
     author_id = data['author_id']
     author = guild.get_member(author_id)
+    if not author:
+        author = guild.fetch_member(author_id)
     content = data['content']
     embed = make_embed(title=author.display_name, content=content, icon=author.avatar_url)
     sent = data['sent']

--- a/meowth/utils/formatters.py
+++ b/meowth/utils/formatters.py
@@ -247,7 +247,8 @@ def deleted_message_embed(bot, data):
     author_id = data['author_id']
     author = guild.get_member(author_id)
     if not author:
-        author = guild.fetch_member(author_id)
+        # TODO
+        pass
     content = data['content']
     embed = make_embed(title=author.display_name, content=content, icon=author.avatar_url)
     sent = data['sent']


### PR DESCRIPTION
Turned off caching all members on startup.
- If a user_id is not in the member cache get_member will return None, so added a check for that and fetch_member if needed.
- Alternatively if get_member is only called to resolve the nickname, replaced it with the id and let discord resolve it.

Left 6 TODOs:
admin_cog: 35
raid/objects: 671
trade_cog: 90,99
core/context: 523
utils/formatters: 250

fetch_member is a coroutine and the above aren't async functions
