### PR TITLE
store guild_id

### DIFF
--- a/meowth/exts/admin/admin_cog.py
+++ b/meowth/exts/admin/admin_cog.py
@@ -271,7 +271,7 @@ class AdminCog(Cog):
         if data:
             d = dict(data[0])
         else:
-            d = {'channelid': channel_id}
+            d = {'channelid': channel_id, 'guild_id': ctx.guild.id}
         d['city'] = city
         d['lat'] = lat
         d['lon'] = lon


### PR DESCRIPTION
This fixes the bug of cross posting not working (not retrospectively).

Any channel where `!setlocation` was the first command to be run does not have its guild id set in the database.